### PR TITLE
Added zippy starter's shadcn UI theme generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/'>sha
 
 ## Apps
 ### Colors and Customizations
+- [zippy starter's shadcn/ui theme generator.](https://zippystarter.com/tools/shadcn-ui-theme-generator) - Easily create custom themes from a single colour that you can copy and paste into your apps.
 - [10000+Themes for shadcn/ui](https://ui.jln.dev/) - 10000+ Themes for shadcn/ui.
 - [ui-colorgen](https://ui-colorgen.vercel.app/) - An application designed to assist you with color configuration of shadcn/ui.
 - [gradient-picker](https://github.com/Illyism/gradient-picker) - Fancy Gradient Picker built with Shadcn UI, Radix UI and Tailwind CSS.


### PR DESCRIPTION
I added `Zippy Starter's theme generator`, which enables users to effortlessly create custom themes from a single color. This tool functions similarly to shadcn/ui's theme generator, but with the added feature of allowing users to select their preferred color using a color picker.

![generator](https://github.com/birobirobiro/awesome-shadcn-ui/assets/61798731/bf97024d-0cf5-4e09-8b21-1985166e11a3)
