### PR TITLE
Added Plugins and Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/'>sha
 - [password-input](https://gist.github.com/mjbalcueva/b21f39a8787e558d4c536bf68e267398) - shadcn/ui custom password input
 
 ## Apps
+
+### VSCode Extensions
+- [shadcn-ui](https://marketplace.visualstudio.com/items?itemName=SuhelMakkad.shadcn-ui): Add components from shadcn/ui directly from VS Code.
+- [vscode-shadcn-svelte](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-svelte&ssr=false#overview): VS Code extension for Shadcn UI components in Svelte projects.
+- [vscode-shadcn-vue](https://marketplace.visualstudio.com/items?itemName=Selemondev.shadcn-vue): Extension for integrating Shadcn UI components into Vue.js projects.
+
 ### Colors and Customizations
 - [zippy starter's shadcn/ui theme generator.](https://zippystarter.com/tools/shadcn-ui-theme-generator) - Easily create custom themes from a single colour that you can copy and paste into your apps.
 - [10000+Themes for shadcn/ui](https://ui.jln.dev/) - 10000+ Themes for shadcn/ui.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/'>sha
 
 ## Apps
 
-### VSCode Extensions
-- [shadcn-ui](https://marketplace.visualstudio.com/items?itemName=SuhelMakkad.shadcn-ui): Add components from shadcn/ui directly from VS Code.
-- [vscode-shadcn-svelte](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-svelte&ssr=false#overview): VS Code extension for Shadcn UI components in Svelte projects.
-- [vscode-shadcn-vue](https://marketplace.visualstudio.com/items?itemName=Selemondev.shadcn-vue): Extension for integrating Shadcn UI components into Vue.js projects.
-
+### Plugins and Extensions
+- [shadcn-ui](https://marketplace.visualstudio.com/items?itemName=SuhelMakkad.shadcn-ui) - Add components from shadcn/ui directly from VS Code.
+- [vscode-shadcn-svelte](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-svelte&ssr=false#overview) - VS Code extension for Shadcn UI components in Svelte projects.
+- [vscode-shadcn-vue](https://marketplace.visualstudio.com/items?itemName=Selemondev.shadcn-vue) - Extension for integrating Shadcn UI components into Vue.js projects.
+- [shadcn/ui Components Manager](https://plugins.jetbrains.com/plugin/23479-shadcn-ui-components-manager) - A plugin for Jetbrain products. It allows you to manage your shadcn/ui components across Svelte, React, Vue, and Solid frameworks with this plugin. Simplify tasks like adding, removing, and updating components.
 ### Colors and Customizations
 - [zippy starter's shadcn/ui theme generator.](https://zippystarter.com/tools/shadcn-ui-theme-generator) - Easily create custom themes from a single colour that you can copy and paste into your apps.
 - [10000+Themes for shadcn/ui](https://ui.jln.dev/) - 10000+ Themes for shadcn/ui.


### PR DESCRIPTION
I added the VSCode extensions that I used for installing Shadcn UI components without leaving the editor.

Example shadcn/ui extension:

![image](https://github.com/birobirobiro/awesome-shadcn-ui/assets/61798731/52de00e6-cc2d-4884-9b13-f35fd7c25f8a)