### PR TITLE
feat: :sparkles: Add Kirimase Dev to the Boilerplates / Templates sec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/'>sha
 - [sortable](https://github.com/sadmann7/sortable) - A sortable component built with shadcn/ui, radix ui, and dnd-kit.
 - [time-picker](https://github.com/openstatusHQ/time-picker) - A simple TimePicker for your shadcn/ui project.
 - [uixmat/onborda](https://github.com/uixmat/onborda) - Give your application the onboarding it deserves with Onborda product tour for Next.js
+
 ## Apps
 
 ### Plugins and Extensions
@@ -156,6 +157,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/'>sha
 - [taxonomy](https://github.com/shadcn/taxonomy) - An open source application built using the new router, server components and everything new in Next.js
 - [turborepo-shadcn-ui-tailwindcss](https://github.com/henriqpohl/turborepo-shadcn-ui-tailwindcss) - Turborepo starter with shadcn/ui & Tailwind CSS pre-configured for shared ui components.
 - [turborepo-launchpad](https://github.com/JadRizk/turborepo-launchpad) - A comprehensive monorepo boilerplate for shadcn projects using Turbo. It features a highly scalable setup ideal for developing complex applications with shared components and utilities.
+- [kirimase](https://kirimase.dev/) - A template and boilerplate for quickly starting your next project with shadcn/ui, Tailwind CSS, and Next.js.
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/'>sha
 - [chadnext](https://github.com/moinulmoin/chadnext) - Quick Starter Template includes Next.js 14 App router, shadcn/ui, LuciaAuth, Prisma, Server Actions, Stripe, Internationalization and more.
 - [design-system-template](https://github.com/arevalolance/design-system-template) - Turborepo + TailwindCSS + Storybook + shadcn/ui
 - [horizon-ai-nextjs-shadcn-boilerplate](https://horizon-ui.com/boilerplate-shadcn) - Premium AI NextJS & Shadcn UI Boilerplate + Stripe + Supabase + OAuth
+- [kirimase](https://kirimase.dev/) - A template and boilerplate for quickly starting your next project with shadcn/ui, Tailwind CSS, and Next.js.
 - [magicui-startup-templates](https://magicui.design/docs/templates/startup) - Magic UI Startup template built using shadcn/ui + tailwindcss + framer-motion
 - [next-shadcn-dashboard-starter](https://github.com/Kiranism/next-shadcn-dashboard-starter) - Admin Dashboard Starter with Next.js 14 and shadcn/ui
 - [nextjs-mdx-blog](https://github.com/ChangoMan/nextjs-mdx-blog) - Starter template built with Contentlayer, MDX, shadcn/ui, and Tailwind CSS.
@@ -158,7 +159,6 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/'>sha
 - [taxonomy](https://github.com/shadcn/taxonomy) - An open source application built using the new router, server components and everything new in Next.js
 - [turborepo-shadcn-ui-tailwindcss](https://github.com/henriqpohl/turborepo-shadcn-ui-tailwindcss) - Turborepo starter with shadcn/ui & Tailwind CSS pre-configured for shared ui components.
 - [turborepo-launchpad](https://github.com/JadRizk/turborepo-launchpad) - A comprehensive monorepo boilerplate for shadcn projects using Turbo. It features a highly scalable setup ideal for developing complex applications with shared components and utilities.
-- [kirimase](https://kirimase.dev/) - A template and boilerplate for quickly starting your next project with shadcn/ui, Tailwind CSS, and Next.js.
 
 ## Star History
 


### PR DESCRIPTION
### Description
I added the Kirimase Dev project to the Boilerplates / Templates section. Kirimase Dev is a template and boilerplate to quickly start your next project with shadcn/ui, Tailwind CSS, and Next.js.

### What is Kirimase?
Kirimase is a command-line tool (CLI) for building full-stack Next.js apps faster. It supercharges your development workflow, allowing you to quickly integrate packages and scaffold resources for your application with best practices in mind.

In a matter of seconds, Kirimase installs and configures your choice of ORM (Prisma or Drizzle), Authentication (Auth.js, Clerk, Lucia, Kinde), Component Library (Shadcn-UI), Payments (Stripe), and Email (Resend). Kirimase also sets up tRPC with both client and server-side implementations ready to go. Unlike template repos, each option is modular, meaning you can pick any combination of packages you would like.

With Kirimase's generate command, developers can jump right into building actual features without the need to manually create boilerplate code. After defining a new data entity, the command swiftly generates all boilerplate necessary for basic CRUD operations, including everything from the schema to server actions to routes & components. Build at the speed of thought!

### Links
- [Kirimase Dev Website](https://kirimase.dev/)
- [GitHub Repository](https://github.com/nicoalbanese/kirimase)

### Checklist
- [x] Verified that my addition is in the correct section.
- [x] Checked the links to ensure they work correctly.
