### PR TITLE
feat: Add Proxmox Helper Scripts to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [imgsrc](https://imgsrc.io/) - Generate beautiful Open Graph images with zero effort.
 - [invoify](https://github.com/aliabb01/invoify) - An invoice generator app built using Next.js, Typescript, and shadcn/ui
 - [pastecode](https://github.com/Quorin/PasteCode.app) - Pastebin alternative built with Typescript, Next.js, Drizzle, Shadcn, RSC
+- [proxmox-helper-scripts](https://github.com/BramSuurdje/proxmox-helper-scripts) - A catalog of scripts for your Proxmox VE homelab, built with the Next.js App Router and styled with shadcn/ui.
 - [QuackDB](https://github.com/mattf96s/QuackDB) - Open-source in-browser DuckDB SQL editor
 - [shadcn-pricing-page-generator](https://shipixen.com/shadcn-pricing-page) - The easiest way to get a React pricing page with shadcn/ui, Radix UI and/or Tailwind CSS.
 - [translate-app](https://github.com/developaul/translate-app) - Translate App using TypeScript, Tailwind CSS, NextJS, Bun, shadcn/ui, AI-SDK/OpenAI, Zod


### PR DESCRIPTION
---
name: feat: Add Proxmox Helper Scripts website

about: Added a awesome site build with shadcn/ui to the list.

labels: feature

---

## Describe the awesome thing you want to add

**What is it?** 

The "proxmox-helper-scripts" project is a set of scripts to help manage a Proxmox VE homelab. It uses the Next.js App Router for routing and navigation and is styled with the ShadCN. These scripts streamline and automate tasks within the Proxmox Virtual Environment, simplifying virtual machine and infrastructure management.

**What category does it belong to?** 
Tools

Here are some screenshots
![image](https://github.com/user-attachments/assets/f74a845b-c217-4e54-94d4-2dd98b02fc2f)
![image](https://github.com/user-attachments/assets/f289c697-cb3a-45f1-bee3-94505517b554)

## Checklist

- [X] I checked that it is in alphabetical order.
- [X] I have checked that the awesome thing is not already listed.
- [X] I have provided a clear and concise description of the awesome thing.
- [X] I have provided a link to the awesome thing.
- [X] I have assigned the correct category to the awesome thing.

**Please note:** If you are adding a new category, you will need to create a new section in the `README.md` file. Please make sure to update the table of contents as well.

**Important:** The idea of this repository is to bring together free projects for open-source contributions. If the proposed addition is an entirely paid project, the PR will be closed.