### PR TITLE
Add nextjs link pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [neobrutalism-components](https://github.com/ekmas/neobrutalism-components) - Collection of neobrutalism-styled Tailwind React and shadcn/ui components.
 - [nextjs-components](https://components.bridger.to/) - A collection of Next.js components build with TypeScript, React, shadcn/ui, Craft UI, and Tailwind CSS.
 - [nextjs-dnd](https://github.com/sujjeee/nextjs-dnd) - Sortable Drag and Drop with Next.js, shadcn/ui, and dnd-kit.
+- [nextjs-link-pagination](https://shadcn-next-link-pagination.vercel.app) - shadcn paging/pagination that uses Nextjs Links and search params (like `example.com?page=4`)
 - [novel](https://github.com/steven-tey/novel) - Novel is a Notion-style WYSIWYG editor with AI-powered autocompletion. Built with [Tiptap](https://tiptap.dev/) + [Vercel AI SDK](https://sdk.vercel.ai/docs).
 - [password-input](https://gist.github.com/mjbalcueva/b21f39a8787e558d4c536bf68e267398) - shadcn/ui custom password input.
 - [phone-input-shadcn-ui](https://www.armand-salle.fr/post/phone-input-shadcn-ui) - Custom phone number component built with shadcn/ui.


### PR DESCRIPTION
---
name: feat: Add nextjs link pagination

about: Add a shadcn pagination wrapper that uses nextjs links

labels: feature

---

## Describe the awesome thing you want to add

**What is it?** Pagination wrapper that uses Nextjs links to handle paging

**What category does it belong to?** Libs and Components

**Anything else? (optional)**

https://shadcn-next-link-pagination.vercel.app/

![Screen Recording 2024-07-30 at 4 32 03 PM](https://github.com/user-attachments/assets/853f1aa8-6cff-4a7f-a5e0-12dad555ca2b)


## Checklist

- [x] I checked that it is in alphabetical order.
- [x] I have checked that the awesome thing is not already listed.
- [x] I have provided a clear and concise description of the awesome thing.
- [x] I have provided a link to the awesome thing.
- [x] I have assigned the correct category to the awesome thing.
