### PR TITLE
Add shadcn-registry-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [shadcn-multi-select-component](https://github.com/sersavan/shadcn-multi-select-component) - A multi-select component designed with shadcn/ui.
 - [shadcn-phone-input-2](https://github.com/damianricobelli/shadcn-phone-input) - Simple and formatted phone input component built with shadcn/ui y libphonenumber-js.
 - [shadcn-phone-input](https://github.com/omeralpi/shadcn-phone-input) - Customizable phone input component with proper validation for any country.
+- [shadcn-registry-template](https://github.com/vantezzen/shadcn-registry-template) - Template repository for building a custom component registry for shadcn/ui.
 - [shadcn-stepper](https://github.com/damianricobelli/shadcn-stepper) - A complete stepper component built with shadcn/ui.
 - [shadcn-table-v2](https://github.com/sadmann7/shadcn-table) - shadcn/ui table component with server-side sorting, filtering, and pagination.
 - [shadcn-timeline](https://github.com/timDeHof/shadcn-timeline) - Customizable and re-usable timeline component for you to use in your projects. Built on top of shadcn.


### PR DESCRIPTION
---
name: feat: Add shadcn-registry-template

about: Add shadcn-registry-template for building custom component registries

labels: feature

---

## Describe the awesome thing you want to add

**What is it?** 

shadcn 2 and later allow installing components from a custom registry like `npx shadcn-ui@latest add https://raw.githubusercontent.com/vantezzen/auto-form/main/registry/auto-form.json`. This template allows you to easily create your own registry for your components.

**What category does it belong to?** (Libs and Components, Apps, Ports, Design System, Boilerplates/Templates)

Libs

**Anything else? (optional)** (e.g. screenshots, additional information, etc.)

I build this for [auto-form](https://github.com/vantezzen/auto-form) but extracted this since its useful for all custom components.

## Checklist

- [x] I checked that it is in alphabetical order.
- [x] I have checked that the awesome thing is not already listed.
- [x] I have provided a clear and concise description of the awesome thing.
- [x] I have provided a link to the awesome thing.
- [x] I have assigned the correct category to the awesome thing.

**Please note:** If you are adding a new category, you will need to create a new section in the `README.md` file. Please make sure to update the table of contents as well.

**Important:** The idea of this repository is to bring together free projects for open-source contributions. If the proposed addition is an entirely paid project, the PR will be closed.