### PR TITLE
feat: Add nextMotion template

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [horizon-ai-nextjs-shadcn-boilerplate](https://horizon-ui.com/boilerplate-shadcn) - Premium AI NextJS & shadcn/ui Boilerplate + Stripe + Supabase + OAuth
 - [kirimase](https://kirimase.dev/) - A template and boilerplate for quickly starting your next project with shadcn/ui, Tailwind CSS, and Next.js.
 - [magicui-startup-templates](https://magicui.design/docs/templates/startup) - Magic UI Startup template built using shadcn/ui + tailwindcss + framer-motion
+- [nextMotion](https://github.com/yoyocharlie/nextMotion) - Webdev portfolio template with nodemailer integrated for easy contact form setup. Uses shadcn/ui + tailwindcss + framer-motion.
 - [next-shadcn-dashboard-starter](https://github.com/Kiranism/next-shadcn-dashboard-starter) - Admin Dashboard Starter with Next.js 14 and shadcn/ui
 - [next-starter](https://github.com/Skolaczk/next-starter) - A Next.js starter template, packed with features like TypeScript, Tailwind CSS, Next-auth, Eslint, Stripe, testing tools and more. Jumpstart your project with efficiency and style.
 - [nextjs-mdx-blog](https://github.com/ChangoMan/nextjs-mdx-blog) - Starter template built with Contentlayer, MDX, shadcn/ui, and Tailwind CSS.


### PR DESCRIPTION
Add a Webdev portfolio template that uses shadcn/ui, Next.js, Framer-motion, and TypeScript. Built-in contact form hooked up to nodemailer for minimal setup to start receiving contact form emails.

https://github.com/yoyocharlie/nextMotion

**Category**: Boilerplates/Templates

## Checklist

- [x] I checked that it is in alphabetical order.
- [x] I have checked that the awesome thing is not already listed.
- [x] I have provided a clear and concise description of the awesome thing.
- [x] I have provided a link to the awesome thing.
- [x] I have assigned the correct category to the awesome thing.