### PR TITLE
add shadcn-theme-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [simplekit](https://github.com/vaunblu/SimpleKit) - Responsive connect wallet and account component built on top of Wagmi and shadcn/ui.
 - [sortable](https://github.com/sadmann7/sortable) - A sortable component built with shadcn/ui, radix ui, and dnd-kit.
 - [stocks](https://github.com/aryanvichare/stocks) - Stock Picker using Next.js, React Server Components, and shadcn/ui charts.
+- [stunning-ui](stunningui.design) - Stunning UI is a collection of interactive Tailwind CSS components built for Vue and Nuxt.
 - [time-picker](https://github.com/openstatusHQ/time-picker) - A simple TimePicker for your shadcn/ui project.
 - [tremor-raw](https://github.com/tremorlabs/tremor-raw) - Copy & paste React components to build modern web applications. Good for building charts.
 - [ui-beats](https://uibeats.com) - Collection of Animated React Components.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [translate-app](https://github.com/developaul/translate-app) - Translate App using TypeScript, Tailwind CSS, NextJS, Bun, shadcn/ui, AI-SDK/OpenAI, Zod
 - [typelabs](https://github.com/imsandeshpandey/typelabs) - MonkeyType inspired typing test app built with React, shadcn, and Zustand at it's core.
 - [ui-builder](https://github.com/olliethedev/ui-builder) - A React component editor that provides a no-code, visual way to create UIs, fully compatible with shadcn/ui and custom components.
-- [ui-fonts](https://ui-fonts.app) - Test and preview fonts in real-time for all your design needs. Choose the perfect typeface with ease.
+- [ui-fonts](https://www.uifonts.app/) - Test and preview fonts in real-time for all your design needs. Choose the perfect typeface with ease.
 - [v0](https://v0.dev/) - Vercel's generative UI system, built on shadcn/ui and TailwindCSS, allows effortless UI generation from text prompts and/or images. It produces React and HTML code, integration is also possible via v0 CLI command.
 - [wallhaven-desktop](https://github.com/ErKeLost/wallhaven-desktop) - Wallhaven Wallpaper software desktop. Create a wallhaven api based client , a true wallpaper software. use Farm , Tauri , React19, shadcn/ui.
 - [xuneix](https://xuneix.theteleporter.me/) - A link rotation tool for enhanced admin panel security. It includes dynamic URLs, expiring tokens, customizable rotation. Easily setup with shadcn/ui. Integrates with Vercel KV.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [tinte](https://tinte.railly.dev/) - An opinionated VS Code Theme Generator 🎨
 - [translate-app](https://github.com/developaul/translate-app) - Translate App using TypeScript, Tailwind CSS, NextJS, Bun, shadcn/ui, AI-SDK/OpenAI, Zod
 - [typelabs](https://github.com/imsandeshpandey/typelabs) - MonkeyType inspired typing test app built with React, shadcn, and Zustand at it's core.
-- [ui-builder](https://github.com/olliethedev/ui-builder) - A React component editor that provides a no-code, visual way to create UIs, fully compatible with shadcn/ui and custom components. 
+- [ui-builder](https://github.com/olliethedev/ui-builder) - A React component editor that provides a no-code, visual way to create UIs, fully compatible with shadcn/ui and custom components.
+- [ui-fonts](https://ui-fonts.app) - Test and preview fonts in real-time for all your design needs. Choose the perfect typeface with ease.
 - [v0](https://v0.dev/) - Vercel's generative UI system, built on shadcn/ui and TailwindCSS, allows effortless UI generation from text prompts and/or images. It produces React and HTML code, integration is also possible via v0 CLI command.
 - [wallhaven-desktop](https://github.com/ErKeLost/wallhaven-desktop) - Wallhaven Wallpaper software desktop. Create a wallhaven api based client , a true wallpaper software. use Farm , Tauri , React19, shadcn/ui.
 - [xuneix](https://xuneix.theteleporter.me/) - A link rotation tool for enhanced admin panel security. It includes dynamic URLs, expiring tokens, customizable rotation. Easily setup with shadcn/ui. Integrates with Vercel KV.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [simplekit](https://github.com/vaunblu/SimpleKit) - Responsive connect wallet and account component built on top of Wagmi and shadcn/ui.
 - [sortable](https://github.com/sadmann7/sortable) - A sortable component built with shadcn/ui, radix ui, and dnd-kit.
 - [stocks](https://github.com/aryanvichare/stocks) - Stock Picker using Next.js, React Server Components, and shadcn/ui charts.
-- [stunning-ui](stunningui.design) - Stunning UI is a collection of interactive Tailwind CSS components built for Vue and Nuxt.
+- [stunning-ui](https://stunningui.design) - Stunning UI is a collection of interactive Tailwind CSS components built for Vue and Nuxt.
 - [time-picker](https://github.com/openstatusHQ/time-picker) - A simple TimePicker for your shadcn/ui project.
 - [tremor-raw](https://github.com/tremorlabs/tremor-raw) - Copy & paste React components to build modern web applications. Good for building charts.
 - [ui-beats](https://uibeats.com) - Collection of Animated React Components.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [file-uploader](https://github.com/sadmann7/file-uploader) - A file uploader built with shadcn/ui and react-dropzone.
 - [file-vault](https://github.com/ManishBisht777/file-vault) - File upload component for React.
 - [fusion-ui](https://github.com/nyxb-ui/ui) - Fusion UI library combining shadcn/ui and MagicUI.
+- [gluestack-ui](https://gluestack.io) - React & React Native Components & Patterns - copy-paste components & patterns crafted with Tailwind CSS (NativeWind)
 - [ibelick/background-snippet](https://bg.ibelick.com/) - Ready to use collection of modern background snippets.
 - [image-upload-shadcn](https://github.com/kushagrasarathe/image-upload-shadcn) - Image upload component
 - [indie-ui](https://github.com/Ali-Hussein-dev/indie-ui) - UI components with variants - [Docs](https://ui.indie-starter.dev)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [qualmeuip](https://www.qualmeuip.xyz/) - Find out your IP address and test your internet speed
 - [shadcn-form-builder](https://shadcn-form-build.vercel.app/) - Create forms with Shadcn, react-hooks-form and zod within minutes
 - [shadcn-pricing-page-generator](https://shipixen.com/shadcn-pricing-page) - The easiest way to get a React pricing page with shadcn/ui, Radix UI and/or Tailwind CSS.
+- [shadcn-theme-editor](https://shadcnthemeeditor.vercel.app) - Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects
 - [shadcn-zod-form](https://github.com/ilyichv/shadcn-zod-form) - CLI tool to generate shadcn/ui forms from zod schemas.
 - [sharable-form-builder](https://github.com/ayoubben18/sharable-form-builder) - A sharable form builder for creating forms and sharing your form link, based on shadcn/ui and Next.js.
 - [tinte](https://tinte.railly.dev/) - An opinionated VS Code Theme Generator 🎨

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [nextjs-components](https://components.bridger.to/) - A collection of Next.js components build with TypeScript, React, shadcn/ui, Craft UI, and Tailwind CSS.
 - [nextjs-dnd](https://github.com/sujjeee/nextjs-dnd) - Sortable Drag and Drop with Next.js, shadcn/ui, and dnd-kit.
 - [nextjs-link-pagination](https://shadcn-next-link-pagination.vercel.app) - shadcn paging/pagination that uses Nextjs Links and search params
+- [next-shadcn-dashboard-starter](https://github.com/Kiranism/next-shadcn-dashboard-starter) - Admin Dashboard Starter with Nextjs 14 and Shadcn UI
 - [novel](https://github.com/steven-tey/novel) - Novel is a Notion-style WYSIWYG editor with AI-powered autocompletion. Built with [Tiptap](https://tiptap.dev/) + [Vercel AI SDK](https://sdk.vercel.ai/docs).
 - [number-flow](https://number-flow.barvian.me/) - A React component to transition, localize, and format numbers. Dependency-free. Accessible. Customizable.
 - [origin-ui](https://originui.com/) - Beautiful UI components built with Tailwind CSS and Next.js.


### PR DESCRIPTION
---
name: "feat: add shadcn-theme-editor"
about: "Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects"
labels:
  - Tools
---

