### PR TITLE
Added React-based PDF flipbook viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 - [progress-button](https://github.com/tomredman/ProgressButton) - An extension of shadcn/ui button component that uses a state machine to drive a progress UX.
 - [react-dnd-kit-tailwind-shadcn-ui](https://github.com/Georgegriff/react-dnd-kit-tailwind-shadcn-ui) - Drag and drop Accessible kanban board implementing using React, dnd-kit, tailwind, and shadcn/ui.
 - [react-highlight-popover](https://react-highlight-popover.omsimos.com) - A headless react component for creating popovers on text selection with zero dependencies.
+- [react-pdf-flipbook-viewer](https://github.com/mohitkumawat310/react-pdf-flipbook-viewer) - A React & shadcn based PDF flipbook viewer that allows users to view PDF documents in a flipbook format with many advance features like Zoom, Fullscreen, etc.
 - [react-select](https://gist.github.com/ilkou/7bf2dbd42a7faf70053b43034fc4b5a4) Implementation of the react-select library with shadcn styling. Support for Select, Async-Select, Multi-Select with many configurable options
 - [recursive-dnd-kanban-board](https://github.com/mehrdadrafiee/recursive-dnd-kanban-board) - Recursively-generated drag and drop Accessible kanban board implementing using Next.js, @dnd-kit, tailwind and shadcn/ui.
 - [roadmap-ui](https://github.com/haydenbleasel/roadmap-ui) - Composable React components for building interactive roadmaps.


### PR DESCRIPTION
---
name: "feat: Add new awesome thing"
about: "Add a new awesome thing related to shadcn/ui"
labels:
  - feature
---

## Describe the awesome thing you want to add

**What is it?** 
React-based PDF flipbook viewer that allows users to view PDF documents in a flipbook format. It is built using Next.js and various other libraries to provide a seamless and interactive experience.

**What category does it belong to?** (Libs and Components, Apps, Ports, Design System, Boilerplates/Templates)
Libs and Components

**Anything else? (optional)** (e.g. screenshots, additional information, etc.)

![image](https://github.com/user-attachments/assets/fc24d765-65d6-4b51-bac7-ecf210a5008c)
![image](https://github.com/user-attachments/assets/58215c15-6b84-4241-ad33-ec06931bb213)

## Checklist

- [x] I checked that it is in alphabetical order.
- [x] I have checked that the awesome thing is not already listed.
- [x] I have provided a clear and concise description of the awesome thing.
- [x] I have provided a link to the awesome thing.
- [x] I have assigned the correct category to the awesome thing.

**Please note:** If you are adding a new category, you will need to create a new section in the `README.md` file. Please make sure to update the table of contents as well.

**Important:** The idea of this repository is to bring together free projects for open-source contributions. If the proposed addition is an entirely paid project, the PR will be closed.
