### PR TITLE
feat: add supabase-shadcn-database-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 | spectrum-ui | Collection using Aceternity UI Magic UI. | https://github.com/arihantcodes/spectrum-ui |
 | stocks | Stock Picker with Next.js charts. | https://github.com/aryanvichare/stocks |
 | stunning-ui | Interactive Tailwind components for Vue. | https://stunningui.design |
+| supabase-shadcn-database-example | supabase + shadcn/ui datatable | https://github.com/thisisfel1x/supabase-shadcn-database-example |
 | supercharged-shadcn-components | Type-safe form components collection. | https://github.com/slickwit/supercharged-shadcn-components |
 | time-picker | Simple TimePicker component. | https://github.com/openstatusHQ/time-picker |
 | tremor-raw | Components for charts and dashboards. | https://github.com/tremorlabs/tremor-raw |


### PR DESCRIPTION
---
name: "feat: add supabase-shadcn-database-example"
about: "Propose adding a new resource related to shadcn/ui"
labels:
  - feature
---

## Describe the awesome resource you want to add

**What is it?**  
This is a demo project that integrates Supabase with TanStack Table, showcasing how to efficiently fetch, filter, and display data with server-side rendering. The project extends the components from [shadcn's data table example](https://ui.shadcn.com/docs/components/data-table) with additional functionalities like lazy loading, table size calculations, and basic filtering.

**Which section does it belong to?**  
- Libs and Components

**Additional Details (optional)**  
The project uses Supabase for database interaction, TanStack Table for data visualization, and shadcn/ui. The code includes example implementations for common use cases.

- **Link:** [GitHub Repository](https://github.com/thisisfel1x/supabase-shadcn-database-example)  
- **Screenshots/Demo:** [here](https://supabase-shadcn-database-example.vercel.app/)

## Checklist

- [x] I verified that the resource is listed in alphabetical order within its section.
- [x] I checked that the resource is not already listed.
- [x] I provided a clear and concise description of the resource.
- [x] I included a valid and working link to the resource.
- [x] I assigned the correct section to the resource.
