### PR TITLE
docs: 🗒️ add shadcn-storybook-registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 
 | Name                     | Description                                                                                                     | Link                                                                                      |
 |--------------------------|-----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-| shadcn-storybook-registry| Repository of stories for the shadcn components. Quickly get the atomic level components documented in Storybook.| [Link](https://registry.lloydrichards.dev/)                                             |
+| shadcn-storybook-registry| Registry of stories for the shadcn components. Quickly get the atomic level components documented in Storybook.| [Link](https://registry.lloydrichards.dev/)                                             |
 | shadcn-ui-components     | Every component recreated in Figma.                                                                            | [Link](https://www.figma.com/community/file/1342715840824755935/shadcn-ui-components)            |
 | shadcn-ui-storybook (JheanAntunes) | All shadcn/ui components registered in the storybook by JheanAntunes.                                     | [Link](https://65711ecf32bae758b457ae34-uryqbzvojc.chromatic.com/)                               |
 | shadcn-ui-storybook (fellipeutaka) | All shadcn/ui components registered in the storybook by fellipeutaka.                                     | [Link](https://fellipeutaka-ui.vercel.app/?path=/docs/components-accordion--docs)               |

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 
 | Name                     | Description                                                                                                     | Link                                                                                      |
 |--------------------------|-----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| shadcn-storybook-registry| Repository of stories for the shadcn components. Quickly get the atomic level components documented in Storybook.| [Link](https://registry.lloydrichards.dev/)                                             |
 | shadcn-ui-components     | Every component recreated in Figma.                                                                            | [Link](https://www.figma.com/community/file/1342715840824755935/shadcn-ui-components)            |
 | shadcn-ui-storybook (JheanAntunes) | All shadcn/ui components registered in the storybook by JheanAntunes.                                     | [Link](https://65711ecf32bae758b457ae34-uryqbzvojc.chromatic.com/)                               |
 | shadcn-ui-storybook (fellipeutaka) | All shadcn/ui components registered in the storybook by fellipeutaka.                                     | [Link](https://fellipeutaka-ui.vercel.app/?path=/docs/components-accordion--docs)               |


### PR DESCRIPTION
---
name: "docs: add shadcn-storybook-registry"
about: "Registry of stories for the shadcn components. Quickly get the atomic level components documented in Storybook."
labels:
  - registry
  - storybook
---

## Describe the awesome resource you want to add

**What is it?**  Design System  

After trying to add storybook documentation to the cli (https://github.com/shadcn-ui/ui/pull/1561) and with the release of v2.3.0 and introductions of registries, I've moved the work from the PR over to its own dedicated [repo](https://github.com/lloydrichards/shadcn-storybook-registry) and [registry](https://registry.lloydrichards.dev/).  This should allow anyone to pull in the story files using the shadcn cli:

```bash
npx shadcn@latest add https://registry.lloydrichards.dev/registry/button-story
```

<img width="1449" alt="Screenshot 2025-02-07 at 18 24 11" src="https://github.com/user-attachments/assets/787ae516-be87-40ad-b50d-d9622c1b2481" />

## Checklist

- [x] I verified that the resource is listed in alphabetical order within its section.
- [x] I checked that the resource is not already listed.
- [x] I provided a clear and concise description of the resource.
- [x] I included a valid and working link to the resource.
- [x] I assigned the correct section to the resource.
