### PR TITLE
Feat: Resolve https://github.com/birobirobiro/awesome-shadcn-ui/issues/197

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,24 +8,24 @@ labels:
 ## Describe the awesome resource you want to add
 
 **What is it?**  
+- 
 
-**Which section does it belong to?**  
-- Libs and Components  
-- Plugins and Extensions  
-- Colors and Customizations  
-- Animations  
-- Tools  
-- Websites and Portfolios Inspirations  
-- Platforms  
-- Ports  
-- Design System  
-- Boilerplates / Templates  
+## **Which section does it belong to?**  
+- [ ] Libs and Components  
+- [ ] Plugins and Extensions  
+- [ ] Colors and Customizations  
+- [ ] Animations  
+- [ ] Tools  
+- [ ] Websites and Portfolios Inspirations  
+- [ ] Platforms  
+- [ ] Ports  
+- [ ] Design System  
+- [ ] Boilerplates / Templates  
 
 **Additional Details (optional)**  
 - Screenshots, demos, or any other useful information.
 
-## Checklist
-
+## **Checklist**
 - [ ] I verified that the resource is listed in alphabetical order within its section.
 - [ ] I checked that the resource is not already listed.
 - [ ] I provided a clear and concise description of the resource.
@@ -35,5 +35,13 @@ labels:
 **Important Notes:**  
 1. If you are introducing a new section, you must also add it to the `README.md` file and update the table of contents accordingly.  
 2. This repository focuses on open-source and freely accessible projects. Paid or fully commercial resources will not be accepted.  
+
+**DO NOT add a date** - our automated system will add the current date to your entry.
+
+**Format your entry like this:**
+
+```markdown
+| Name | Description | [Link](Your_Link_Here) |
+```
 
 Thank you for contributing to the awesome-shadcn/ui repository!

--- a/.github/workflows/add-dates.yml
+++ b/.github/workflows/add-dates.yml
@@ -1,0 +1,32 @@
+name: Add Dates to New Resources
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'README.md'
+
+jobs:
+  add-dates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Add dates to new resources
+        run: node scripts/add-dates.js
+
+      - name: Commit changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add README.md
+          git commit -m "Add dates to new resources" || echo "No changes to commit"
+          git push

--- a/.github/workflows/add-dates.yml
+++ b/.github/workflows/add-dates.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       - name: Add dates to new resources
         run: node scripts/add-dates.js

--- a/.github/workflows/add-dates.yml
+++ b/.github/workflows/add-dates.yml
@@ -28,5 +28,5 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add README.md
-          git commit -m "Add dates to new resources" || echo "No changes to commit"
+          git diff --quiet && git diff --staged --quiet || git commit -m "Add dates to new resources"
           git push

--- a/README.md
+++ b/README.md
@@ -24,32 +24,32 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 
 | Name | Description | Link | Date |
 |------|-------------|------|------|
-| 21st.dev | Open source npm for shadcn/ui components. Also: Dribble for design engineers. Install UI components via shadcn CLI, or publish your own. | [Link](https://21st.dev/) | 2024-12-06 | 2024-12-06 |
-| aceternity-ui | Copy paste the most trending react components without having to worry about styling and animations. | [Link](https://ui.aceternity.com/) | 2024-12-06 | 2024-12-06 |
-| assistant-ui | React Components for AI Chat. | [Link](https://github.com/Yonom/assistant-ui) | 2024-09-23 | 2024-09-23 |
-| autocomplete-select-shadcn-ui | Autocomplete component built with shadcn/ui and Fancy Multi Select by Maximilian Kaske. | [Link](https://www.armand-salle.fr/post/autocomplete-select-shadcn-ui) | 2024-04-07 | 2024-04-07 |
+| 21st.dev | Open source npm for shadcn/ui components. Also: Dribble for design engineers. Install UI components via shadcn CLI, or publish your own. | [Link](https://21st.dev/) | 2024-12-06 |
+| aceternity-ui | Copy paste the most trending react components without having to worry about styling and animations. | [Link](https://ui.aceternity.com/) | 2024-12-06 |
+| assistant-ui | React Components for AI Chat. | [Link](https://github.com/Yonom/assistant-ui) | 2024-09-23 |
+| autocomplete-select-shadcn-ui | Autocomplete component built with shadcn/ui and Fancy Multi Select by Maximilian Kaske. | [Link](https://www.armand-salle.fr/post/autocomplete-select-shadcn-ui) | 2024-04-07 |
 | auto-form | A React component that automatically creates a shadcn/ui form based on a zod schema. | [Link](https://github.com/vantezzen/auto-form) | 2024-04-29 | 2024-04-29 |
 | async-select | Async Select component built with shadcn/ui with debounce search. | [Link](https://async.rdsx.dev) | 2024-07-22 | 2024-07-22 |
-| big-calendar | A modern, feature-rich calendar application with multiple viewing options built using Next.js, TypeScript, and Tailwind CSS. | [Link](https://github.com/lramos33/big-calendar) | 2025-03-08 | 2025-03-08 |
-| bundui | A collection of reusable animated components built with Tailwind CSS and Framer Motion. | [Link](https://bundui.io) | 2024-09-23 | 2024-09-23 |
-| calendar | React/shadcn full calendar like Google Calendar | [Link](https://github.com/charlietlamb/calendar) | 2024-05-03 | 2024-05-03 |
-| capture-photo | Browser-based React component for camera functionalities in web applications. | [Link](https://github.com/UretzkyZvi/capture-photo) | 2024-05-06 | 2024-05-06 |
-| clerk-elements | Composable components for building custom UIs on top of Clerk's APIs. | [Link](https://clerk.com/docs/elements/examples/shadcn-ui) | 2024-06-07 | 2024-06-07 |
-| clerk-shadcn-theme | Synchronize Clerk SignIn/SignUp components with shadcn/ui styles. | [Link](https://github.com/stormynight9/clerk-shadcn-theme) | 2024-06-07 | 2024-06-07 |
-| commerce-ui | Components, blocks and examples to build e-commerce storefronts and apps. | [Link](https://github.com/stackzero-labs/ui) | 2025-02-20 | 2025-02-20 |
-| confirm-dialog | A confirm dialog component built with shadcn/ui. | [Link](https://github.com/Aslam97/react-confirm-dialog) | 2024-07-02 | 2024-07-02 |
-| country-state-dropdown | Component built with Nextjs, Tailwindcss, shadcn/ui & Zustand. | [Link](https://github.com/Jayprecode/country-state-dropdown) | 2024-02-22 | 2024-02-22 |
-| cult-ui | Curated set of animated shadcn-style React components. | [Link](https://www.cult-ui.com/) | 2024-05-29 | 2024-05-29 |
-| credenza | Ready-made responsive modal component for shadcn/ui. | [Link](https://github.com/redpangilinan/credenza) | 2024-06-07 | 2024-06-07 |
-| crypto-charts | Crypto charts made for shadcn/ui using PythNetwork. | [Link](https://github.com/jstnw10/crypto-charts) | 2024-07-16 | 2024-07-16 |
-| date-range-picker-for-shadcn | Multi-month views, text entry, preset ranges, responsive design, and date range comparisons. | [Link](https://github.com/johnpolacek/date-range-picker-for-shadcn) | 2024-04-29 | 2024-04-29 |
-| date-time-picker-shadcn | Datetime Picker for shadNext Project. | [Link](https://shadcn-datetime-picker.vercel.app) | 2024-07-16 | 2024-07-16 |
-| date-time-range-picker-shadcn | Fully featured date-time range picker with multi-month views, timezone support, preset ranges, and modular components for date and time selection. | [Link](https://date-time-range-picker.vercel.app/) | 2025-03-08 | 2025-03-08 |
-| datetime-picker | Datetime picker with timezone support, min/max dates, and month/year selection. | [Link](https://shadcn-datetime-picker-xi.vercel.app) | 2024-07-16 | 2024-07-16 |
-| dnd-dashboard | Dashboard with drop-to-swap layouts using Next.js, shadcn/ui, and swapy. | [Link](https://github.com/olliethedev/dnd-dashboard) | 2024-10-17 | 2024-10-17 |
-| downshift-shadcn-combobox | Combobox/autocomplete component built with shadcn/ui and Downshift. | [Link](https://github.com/TheOmer77/downshift-shadcn-combobox) | 2024-06-27 | 2024-06-27 |
-| drag-to-resize-sidebar | Extended shadcn/ui sidebar component with persisted state drag-to-resize functionality. | [Link](https://github.com/lumpinif/drag-to-resize-sidebar) | 2024-11-21 | 2024-11-21 |
-| druid/ui | Intercom inspired AI chatbot and UI components built on shadcn/ui. | [Link](https://druidui.com/) | 2024-11-21 | 2024-11-21 |
+| big-calendar | A modern, feature-rich calendar application with multiple viewing options built using Next.js, TypeScript, and Tailwind CSS. | [Link](https://github.com/lramos33/big-calendar) | 2025-03-08 |
+| bundui | A collection of reusable animated components built with Tailwind CSS and Framer Motion. | [Link](https://bundui.io) | 2024-09-23 |
+| calendar | React/shadcn full calendar like Google Calendar | [Link](https://github.com/charlietlamb/calendar) | 2024-05-03 |
+| capture-photo | Browser-based React component for camera functionalities in web applications. | [Link](https://github.com/UretzkyZvi/capture-photo) | 2024-05-06 |
+| clerk-elements | Composable components for building custom UIs on top of Clerk's APIs. | [Link](https://clerk.com/docs/elements/examples/shadcn-ui) | 2024-06-07 |
+| clerk-shadcn-theme | Synchronize Clerk SignIn/SignUp components with shadcn/ui styles. | [Link](https://github.com/stormynight9/clerk-shadcn-theme) | 2024-06-07 |
+| commerce-ui | Components, blocks and examples to build e-commerce storefronts and apps. | [Link](https://github.com/stackzero-labs/ui) | 2025-02-20 |
+| confirm-dialog | A confirm dialog component built with shadcn/ui. | [Link](https://github.com/Aslam97/react-confirm-dialog) | 2024-07-02 |
+| country-state-dropdown | Component built with Nextjs, Tailwindcss, shadcn/ui & Zustand. | [Link](https://github.com/Jayprecode/country-state-dropdown) | 2024-02-22 |
+| cult-ui | Curated set of animated shadcn-style React components. | [Link](https://www.cult-ui.com/) | 2024-05-29 |
+| credenza | Ready-made responsive modal component for shadcn/ui. | [Link](https://github.com/redpangilinan/credenza) | 2024-06-07 |
+| crypto-charts | Crypto charts made for shadcn/ui using PythNetwork. | [Link](https://github.com/jstnw10/crypto-charts) | 2024-07-16 |
+| date-range-picker-for-shadcn | Multi-month views, text entry, preset ranges, responsive design, and date range comparisons. | [Link](https://github.com/johnpolacek/date-range-picker-for-shadcn) | 2024-04-29 |
+| date-time-picker-shadcn | Datetime Picker for shadNext Project. | [Link](https://shadcn-datetime-picker.vercel.app) | 2024-07-16 |
+| date-time-range-picker-shadcn | Fully featured date-time range picker with multi-month views, timezone support, preset ranges, and modular components for date and time selection. | [Link](https://date-time-range-picker.vercel.app/) | 2025-03-08 |
+| datetime-picker | Datetime picker with timezone support, min/max dates, and month/year selection. | [Link](https://shadcn-datetime-picker-xi.vercel.app) | 2024-07-16 |
+| dnd-dashboard | Dashboard with drop-to-swap layouts using Next.js, shadcn/ui, and swapy. | [Link](https://github.com/olliethedev/dnd-dashboard) | 2024-10-17 |
+| downshift-shadcn-combobox | Combobox/autocomplete component built with shadcn/ui and Downshift. | [Link](https://github.com/TheOmer77/downshift-shadcn-combobox) | 2024-06-27 |
+| drag-to-resize-sidebar | Extended shadcn/ui sidebar component with persisted state drag-to-resize functionality. | [Link](https://github.com/lumpinif/drag-to-resize-sidebar) | 2024-11-21 |
+| druid/ui | Intercom inspired AI chatbot and UI components built on shadcn/ui. | [Link](https://druidui.com/) | 2024-11-21 |
 | dy-comps | shacn/ui & Framer Motion React components — flexible, responsive & easy to drop into any project. | [Link](https://dycomps.oimmi.com/) | 2025-03-08 |
 | echo-editor | Modern WYSIWYG rich-text editor based on tiptap and shadcn/ui. | [Link](https://github.com/Seedsa/echo-editor) | 2024-06-07 |
 | edil-ozi | React components with Gsap, framer motion, and tailwind. | [Link](https://edilozi.pro/) | 2024-06-27 |

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 
 ## Libs and Components
 
-| Name | Description | Link |
-|------|-------------|------|
+| Name | Description | Link | Date |
+|------|-------------|------|------|
 | 21st.dev | Open source npm for shadcn/ui components. Also: Dribble for design engineers. Install UI components via shadcn CLI, or publish your own. | [Link](https://21st.dev/) |
 | aceternity-ui | Copy paste the most trending react components without having to worry about styling and animations. | [Link](https://ui.aceternity.com/) |
 | assistant-ui | React Components for AI Chat. | [Link](https://github.com/Yonom/assistant-ui) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 
 | Name | Description | Link | Date |
 |------|-------------|------|------|
-| 1Test | This is a test pr. | [Link](https://bankkroll.xyz) |
 | 21st.dev | Open source npm for shadcn/ui components. Also: Dribble for design engineers. Install UI components via shadcn CLI, or publish your own. | [Link](https://21st.dev/) | 2024-12-06 |
 | aceternity-ui | Copy paste the most trending react components without having to worry about styling and animations. | [Link](https://ui.aceternity.com/) | 2024-12-06 |
 | assistant-ui | React Components for AI Chat. | [Link](https://github.com/Yonom/assistant-ui) | 2024-09-23 |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 | stunning-ui | Interactive Tailwind components for Vue. | [Link](https://stunningui.design) | 2024-10-22 |
 | supabase-shadcn-database-example | supabase + shadcn/ui datatable | [Link](https://github.com/thisisfel1x/supabase-shadcn-database-example) | 2024-12-30 |
 | supercharged-shadcn-components | Type-safe form components collection. | [Link](https://github.com/slickwit/supercharged-shadcn-components) | 2024-11-25 |
-| tanstack-ui-table | Customizable table with @tanstack/table and shadcn/ui | 2025-02-27 |
+| tanstack-ui-table | Customizable table with @tanstack/table and shadcn/ui | [Link](https://github.com/drefahl/tanstack-ui-table) |2025-02-27 |
 | time-picker | Simple TimePicker component. | [Link](https://github.com/openstatusHQ/time-picker) | 2024-04-29 |
 | tremor | Components for charts and dashboards. | [Link](https://github.com/tremorlabs/tremor) | 2024-06-15 |
 | twblocks | Website blocks based on shadcn & Radix. | [Link](https://github.com/tommyjepsen/twblocks) | 2024-11-25 |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 | shadcn-iconpicker | React/shadcn simple icon picker using lucide icons. | [Link](https://icon-picker.alan-courtois.fr/) |
 | shadcn-image-cropper | Image cropper with react-image-crop. | [Link](https://github.com/sujjeee/shadcn-image-cropper) |
 | shadcn-linear-combobox | Linear-style task priority combobox. | [Link](https://github.com/damianricobelli/shadcn-linear-combobox)|
+| shadcn-location-picker | Simple google maps location picker. | [Link](https://github.com/brielov/shadcn-location-picker) |
 | shadcn-multi-select-component | Multi-select component. | [Link](https://github.com/sersavan/shadcn-multi-select-component) |
 | shadcn-number-scrubber | Draggable numeric input component. | [Link](https://github.com/camwebby/shadcn-react-number-scrubber) |
 | shadcn-packaged | This is an npm package that exports all shadcn/ui components without the need for a CLI, designed for ease of use. | [Link](https://github.com/anuoua/shadcn-packaged) |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 | crypto-charts | Crypto charts made for shadcn/ui using PythNetwork. | [Link](https://github.com/jstnw10/crypto-charts) |
 | date-range-picker-for-shadcn | Multi-month views, text entry, preset ranges, responsive design, and date range comparisons. | [Link](https://github.com/johnpolacek/date-range-picker-for-shadcn) |
 | date-time-picker-shadcn | Datetime Picker for shadNext Project. | [Link](https://shadcn-datetime-picker.vercel.app) |
+| date-time-range-picker-shadcn | Fully featured date-time range picker with multi-month views, timezone support, preset ranges, and modular components for date and time selection. | [Link](https://date-time-range-picker.vercel.app/) |
 | datetime-picker | Datetime picker with timezone support, min/max dates, and month/year selection. | [Link](https://shadcn-datetime-picker-xi.vercel.app) |
 | dialog-stack | Composable stacked dialogs for shadcn/ui | [Link](https://github.com/haydenbleasel/dialog-stack) |
 | dnd-dashboard | Dashboard with drop-to-swap layouts using Next.js, shadcn/ui, and swapy. | [Link](https://github.com/olliethedev/dnd-dashboard) |

--- a/README.md
+++ b/README.md
@@ -24,331 +24,331 @@ A curated list of awesome things related to <a href='https://ui.shadcn.com/' tar
 
 | Name | Description | Link | Date |
 |------|-------------|------|------|
-| 21st.dev | Open source npm for shadcn/ui components. Also: Dribble for design engineers. Install UI components via shadcn CLI, or publish your own. | [Link](https://21st.dev/) |
-| aceternity-ui | Copy paste the most trending react components without having to worry about styling and animations. | [Link](https://ui.aceternity.com/) |
-| assistant-ui | React Components for AI Chat. | [Link](https://github.com/Yonom/assistant-ui) |
-| autocomplete-select-shadcn-ui | Autocomplete component built with shadcn/ui and Fancy Multi Select by Maximilian Kaske. | [Link](https://www.armand-salle.fr/post/autocomplete-select-shadcn-ui) |
-| auto-form | A React component that automatically creates a shadcn/ui form based on a zod schema. | [Link](https://github.com/vantezzen/auto-form) |
-| async-select | Async Select component built with shadcn/ui with debounce search. | [Link](https://async.rdsx.dev) |
-| big-calendar | A modern, feature-rich calendar application with multiple viewing options built using Next.js, TypeScript, and Tailwind CSS. | [Link](https://github.com/lramos33/big-calendar) |
-| bundui | A collection of reusable animated components built with Tailwind CSS and Framer Motion. | [Link](https://bundui.io) |
-| calendar | React/shadcn full calendar like Google Calendar | [Link](https://github.com/charlietlamb/calendar) |
-| capture-photo | Browser-based React component for camera functionalities in web applications. | [Link](https://github.com/UretzkyZvi/capture-photo) |
-| clerk-elements | Composable components for building custom UIs on top of Clerk's APIs. | [Link](https://clerk.com/docs/elements/examples/shadcn-ui) |
-| clerk-shadcn-theme | Synchronize Clerk SignIn/SignUp components with shadcn/ui styles. | [Link](https://github.com/stormynight9/clerk-shadcn-theme) |
-| commerce-ui | Components, blocks and examples to build e-commerce storefronts and apps. | [Link](https://github.com/stackzero-labs/ui) |
-| confirm-dialog | A confirm dialog component built with shadcn/ui. | [Link](https://github.com/Aslam97/react-confirm-dialog) |
-| country-state-dropdown | Component built with Nextjs, Tailwindcss, shadcn/ui & Zustand. | [Link](https://github.com/Jayprecode/country-state-dropdown) |
-| cult-ui | Curated set of animated shadcn-style React components. | [Link](https://www.cult-ui.com/) |
-| credenza | Ready-made responsive modal component for shadcn/ui. | [Link](https://github.com/redpangilinan/credenza) |
-| crypto-charts | Crypto charts made for shadcn/ui using PythNetwork. | [Link](https://github.com/jstnw10/crypto-charts) |
-| date-range-picker-for-shadcn | Multi-month views, text entry, preset ranges, responsive design, and date range comparisons. | [Link](https://github.com/johnpolacek/date-range-picker-for-shadcn) |
-| date-time-picker-shadcn | Datetime Picker for shadNext Project. | [Link](https://shadcn-datetime-picker.vercel.app) |
-| date-time-range-picker-shadcn | Fully featured date-time range picker with multi-month views, timezone support, preset ranges, and modular components for date and time selection. | [Link](https://date-time-range-picker.vercel.app/) |
-| datetime-picker | Datetime picker with timezone support, min/max dates, and month/year selection. | [Link](https://shadcn-datetime-picker-xi.vercel.app) |
-| dnd-dashboard | Dashboard with drop-to-swap layouts using Next.js, shadcn/ui, and swapy. | [Link](https://github.com/olliethedev/dnd-dashboard) |
-| downshift-shadcn-combobox | Combobox/autocomplete component built with shadcn/ui and Downshift. | [Link](https://github.com/TheOmer77/downshift-shadcn-combobox) |
-| drag-to-resize-sidebar | Extended shadcn/ui sidebar component with persisted state drag-to-resize functionality. | [Link](https://github.com/lumpinif/drag-to-resize-sidebar) |
-| druid/ui | Intercom inspired AI chatbot and UI components built on shadcn/ui. | [Link](https://druidui.com/) |
-| dy-comps | shacn/ui & Framer Motion React components — flexible, responsive & easy to drop into any project. | [Link](https://dycomps.oimmi.com/) |
-| echo-editor | Modern WYSIWYG rich-text editor based on tiptap and shadcn/ui. | [Link](https://github.com/Seedsa/echo-editor) |
-| edil-ozi | React components with Gsap, framer motion, and tailwind. | [Link](https://edilozi.pro/) |
-| emblor | Customizable, accessible tag input component with shadcn/ui. | [Link](https://github.com/JaleelB/emblor) |
-| enhanced-button | Enhanced version of the default shadcn-button component. | [Link](https://github.com/jakobhoeg/enhanced-button) |
-| extend-ui | Reusable components built on shadcn/ui for web applications. | [Link](https://www.extend-ui.com/) |
-| fancy-area | Textarea with @mention support inspired by GitHub's PR comment section. | [Link](https://craft.mxkaske.dev/post/fancy-area) |
-| fancy-box | GitHub PR label selector-inspired Combobox with radix-ui components. | [Link](https://craft.mxkaske.dev/post/fancy-box) |
-| fancy-multi-select | Multi Select Component inspired by campsite.design and cal.com. | [Link](https://craft.mxkaske.dev/post/fancy-multi-select) |
-| fancy-switch | Fancy switch component built with shadcn/ui. | [Link](https://github.com/Aslam97/react-fancy-switch) |
-| farmui | Styled and animated component library with npm package support. | [Link](https://farmui.com) |
-| file-uploader | File uploader with shadcn/ui and react-dropzone. | [Link](https://github.com/sadmann7/file-uploader) |
-| file-vault | File upload component for React. | [Link](https://github.com/ManishBisht777/file-vault) |
-| floating-dragable-card | Dragable and resizable card using shadcn/ui elements. | [Link](https://github.com/nishansanjuka/react-drag-card) |
-| fusion-ui | Library combining shadcn/ui and MagicUI. | [Link](https://github.com/nyxb-ui/ui) |
-| gluestack-ui | React & React Native Components with Tailwind CSS. | [Link](https://gluestack.io) |
-| ibelick/background-snippet | Ready to use collection of modern background snippets. | [Link](https://bg.ibelick.com/) |
-| image-upload-shadcn | Image upload component. | [Link](https://github.com/kushagrasarathe/image-upload-shadcn) |
-| indie-ui | UI components with variants. | [Link](https://github.com/Ali-Hussein-dev/indie-ui) |
-| inspira-ui | UI components for animated interfaces in Vue/NuxtJS. | [Link](https://inspira-ui.com/) |
-| junwen-k/ui-x | Additional beautifully designed components that you can copy and paste into your apps. Accessible. Customizable. Open Source. | [Link](https://ui-x.junwen-k.dev/) |
-| kokonut-ui | Free Modern and Customizable components for Next.js. | [Link](https://kokonut.dev/) |
-| launch-ui | Landing page components with React, Shadcn/ui and Tailwind. | [Link](https://www.launchuicomponents.com/) |
-| lingua-time | Smart datetime picker with natural language input. | [Link](https://github.com/nainglinnkhant/lingua-time) |
-| linked-chart | Chart component linked with data-table. | [Link](https://github.com/ardasisbot/linked-chart) |
-| lukacho-ui | Next Generation UI Components. | [Link](https://ui.lukacho.com/components) |
-| manfromexistence-ui | Components to build beautiful designs. | [Link](https://github.com/manfromexistence/ui) |
-| magicui | React components for landing pages with tailwindcss + framer motion. | [Link](https://magicui.design) |
-| maily.to | Notion-like powerful email editor. | [Link](https://github.com/arikchakma/maily.to) |
-| minimal-tiptap | Minimal WYSIWYG editor with shadcn/ui and tiptap. | [Link](https://github.com/Aslam97/shadcn-minimal-tiptap) |
-| mixcnui | Collection of animated components for Nextjs. | [Link](https://github.com/taqui-786/mixcnui) |
-| multi-selection | Managing multi-selection functionality with highlighter. | [Link](https://github.com/sherifawad/multi-selection-with-add-remove) |
-| mynaui | TailwindCSS and shadcn/ui UI Kit for Figma and React. | [Link](https://mynaui.com/) |
-| neobrutalism-components | Neobrutalism-styled Tailwind React and shadcn/ui components. | [Link](https://github.com/ekmas/neobrutalism-components) |
-| nextjs-components | Next.js components with TypeScript and shadcn/ui. | [Link](https://components.bridger.to/) |
-| nextjs-dnd | Sortable Drag and Drop with Next.js and dnd-kit. | [Link](https://github.com/sujjeee/nextjs-dnd) |
-| nextjs-link-pagination | Pagination using Nextjs Links and search params. | [Link](https://shadcn-next-link-pagination.vercel.app) |
-| nextjs-multi-image-upload | Compact, responsive file uploader with shadcn/ui, React Hook Form, and cloud support (S3/R2). | [Link](https://github.com/jacksonkasi0/nextjs-multi-image-upload) |
-| next-shadcn-dashboard-starter | Admin Dashboard Starter with Nextjs 14 and Shadcn UI. | [Link](https://github.com/Kiranism/next-shadcn-dashboard-starter) |
-| next-stepper | Dynamic multi-step form with Next.js and zustand. | [Link](https://github.com/ebulku/next-stepper) |
-| novel | Notion-style WYSIWYG editor with AI-powered autocompletion. | [Link](https://github.com/steven-tey/novel) |
-| number-flow | React component for number transitions and formatting. | [Link](https://number-flow.barvian.me/) |
-| origin-ui | Beautiful UI components with Tailwind CSS and Next.js. | [Link](https://originui.com/) |
-| password-input | shadcn/ui custom password input. | [Link](https://gist.github.com/mjbalcueva/b21f39a8787e558d4c536bf68e267398) |
-| payment-gateways | Integration of payment gateways with Next.js 14. | [Link](https://github.com/PremPrakashCodes/payment-gateways) |
-| phone-input-shadcn-ui | Custom phone number component with shadcn/ui. | [Link](https://www.armand-salle.fr/post/phone-input-shadcn-ui) |
-| planner | Adaptable scheduling component for React. | [Link](https://github.com/UretzkyZvi/planner) |
-| plate | AI-powered rich-text editor. | [Link](https://github.com/udecode/plate) |
-| plate-select-editor | Rich multi-select editor. | [Link](https://platejs.org/docs/multi-select) |
-| pqoqubbw | Open-source animated icons collection. | [Link](https://icons.pqoqubbw.dev/) |
-| pricing-page-shadcn | Customizable pricing page with Next.js 14. | [Link](https://github.com/m4nute/pricing-page-shadcn) |
-| progress-button | Extended button component with progress UX. | [Link](https://github.com/tomredman/ProgressButton) |
-| react-dnd-kit-tailwind-shadcn-ui | Accessible kanban board with dnd-kit. | [Link](https://github.com/Georgegriff/react-dnd-kit-tailwind-shadcn-ui) |
-| react-highlight-popover | Headless component for text selection popovers. | [Link](https://react-highlight-popover.omsimos.com) |
-| react-pdf-flipbook-viewer | PDF flipbook viewer with zoom and fullscreen. | [Link](https://github.com/mohitkumawat310/react-pdf-flipbook-viewer) |
-| react-select | React-select library with shadcn styling. | [Link](https://gist.github.com/ilkou/7bf2dbd42a7faf70053b43034fc4b5a4) |
-| recursive-dnd-kanban-board | Recursive drag and drop kanban board. | [Link](https://github.com/mehrdadrafiee/recursive-dnd-kanban-board) |
-| roadmap-ui | Components for interactive roadmaps. | [Link](https://github.com/haydenbleasel/roadmap-ui) |
-| search-address | Interactive address search using OpenStreetMap. | [Link](https://github.com/UretzkyZvi/search-address) |
-| shadcn-address-autocomplete | Address autocomplete with Google Places API. | [Link](https://github.com/NiazMorshed2007/shadcn-address-autocomplete) |
-| shadcn-admin | Admin Dashboard UI with shadcn/ui and Vite. | [Link](https://github.com/satnaing/shadcn-admin) |
-| shadcn-blocks | Official pre-made customizable components. | [Link](https://ui.shadcn.com/blocks) |
-| shadcn-blocks-com | Hundreds of extra blocks built with shadcn/ui. | [Link](https://www.shadcnblocks.com) |
-| shadcn-cal | Cal.com monthly calendar replica with shadcn/ui. | [Link](https://shadcn-cal-com.vercel.app/?date=2024-04-29) |
-| shadcn-calendar-heatmap | Modern calendar heatmap alternative. | [Link](https://shadcn-calendar-heatmap.vercel.app/) |
-| shadcn-calendar-component | Calendar date picker component. | [Link](https://github.com/sersavan/shadcn-calendar-component) |
-| shadcn-chat | Customizable chat component. | [Link](https://github.com/jakobhoeg/shadcn-chat) |
-| shadcn-carousel-testimonials | Carousel Testimonials component. | [Link](https://github.com/johanguse/shadcn-carousel-testimonials) |
-| shadcn-chatbot-kit | Customizable chatbot components. | [Link](https://shadcn-chatbot-kit.vercel.app/) |
-| shadcn-color-picker | Color picker with react-color. | [Link](https://shadcn-color-picker.vercel.app/) |
-| shadcn-cookies | Sleek and flexible cookie consent component, designed with shadcn/ui | [Link](https://shadcn-cookies.vercel.app/) |
-| shadcn-cookie-consent | Customizable cookie consent component. | [Link](https://github.com/r2hu1/shadcn-cookie-consent) |
-| shadcn-country-dropdown | ISO 3166 country selector dropdown. | [Link](https://shadcn-country-dropdown.vercel.app/) |
-| shadcn-data-table-advanced-col-opions | DataTable with column resizing. | [Link](https://github.com/danielagg/shadcn-data-table-advanced-col-opions) |
-| shadcn-date-picker | Advanced date picker with various features. | [Link](https://date-picker.luca-felix.com) |
-| shadcn-drag-and-drop-sort | Drag-and-drop sortable list of pills of different widths using dnd-kit. | [Link](https://github.com/crystaltai/shadcn-drag-and-drop) |
-| shadcn-drag-table | Drag-and-drop table component. | [Link](https://github.com/zenoncao/shadcn-drag-table) |
-| shadcn-dropzone | File upload component using React-Dropzone, built with accessibility in mind. | [Link](https://github.com/janglad/shadcn-dropzone) |
-| shadcn-editor | Lexical editor with shadcn theme. | [Link](https://github.com/htmujahid/shadcn-editor) |
-| shadcn-extends | Collection of shadcn/ui components. | [Link](https://github.com/lucioew28/extends) |
-| shadcn-extension | Open-source component collection. | [Link](https://github.com/BelkacemYerfa/shadcn-extension) |
-| shadcn-iconpicker | React/shadcn simple icon picker using lucide icons. | [Link](https://icon-picker.alan-courtois.fr/) |
-| shadcn-image-cropper | Image cropper with react-image-crop. | [Link](https://github.com/sujjeee/shadcn-image-cropper) |
-| shadcn-linear-combobox | Linear-style task priority combobox. | [Link](https://github.com/damianricobelli/shadcn-linear-combobox)|
-| shadcn-location-picker | Simple google maps location picker. | [Link](https://github.com/brielov/shadcn-location-picker) |
-| shadcn-multi-select-component | Multi-select component. | [Link](https://github.com/sersavan/shadcn-multi-select-component) |
-| shadcn-number-scrubber | Draggable numeric input component. | [Link](https://github.com/camwebby/shadcn-react-number-scrubber) |
-| shadcn-packaged | This is an npm package that exports all shadcn/ui components without the need for a CLI, designed for ease of use. | [Link](https://github.com/anuoua/shadcn-packaged) |
-| shadcn-phone-input-2 | Phone input with libphonenumber-js. | [Link](https://github.com/damianricobelli/shadcn-phone-input) |
-| shadcn-phone-input | Phone input with country validation. | [Link](https://github.com/omeralpi/shadcn-phone-input) |
-| shadcn-pricing-page | Responsive pricing component with toggles. | [Link](https://github.com/aymanch-03/shadcn-pricing-page) |
-| shadcn-spinner | Spinner component. | [Link](https://github.com/allipiopereira/shadcn-spinner) |
-| shadcn-stepper | Complete stepper component. | [Link](https://github.com/damianricobelli/shadcn-stepper) |
-| shadcn-table-maker | Tool for creating dynamic tables. | [Link](https://shadcn-table-maker.vercel.app/) |
-| shadcn-table-v2 | Table with server-side features. | [Link](https://github.com/sadmann7/shadcn-table) |
-| shadcn-timeline | Customizable timeline component. | [Link](https://github.com/timDeHof/shadcn-timeline) |
-| shadcn-timeline-2 | Alternative timeline component. | [Link](https://timeline.rilcy.app) |
-| shadcn-tiptap | Custom Tiptap editor extensions. | [Link](https://github.com/NiazMorshed2007/shadcn-tiptap) |
-| shadcn-tree-view | Hierarchical data component. | [Link](https://github.com/mrlightful/shadcn-tree-view) |
-| shadcn-ui-blocks | Collection of responsive UI blocks. | [Link](https://shadcn-ui-blocks.vercel.app/) |
-| shadcn-ui-expansions | Additional useful components. | [Link](https://github.com/hsuanyi-chou/shadcn-ui-expansions) |
-| shadcn-ui-sidebar | Retractable responsive sidebar. | [Link](https://github.com/salimi-my/shadcn-ui-sidebar) |
-| shadcn-ui-templates | Free & Premium templates collection. | [Link](https://shadcnui-templates.com) |
-| shaduxe-ui | Component variants for shadcn/ui. | [Link](https://ui.shaduxe.com) |
-| simple-ai | Components and blocks to easily build AI apps | [Link](https://simple-ai.dev) |
-| simplekit | Wallet and account component for Wagmi. | [Link](https://github.com/vaunblu/SimpleKit) |
-| skiper-ui | Stand out from others with this crazzy ui library built with shad-cn cli | [Link](https://skiper-ui.com/) |
-| solanauth | Solana wallet authentication modal. | [Link](https://solanauth.vercel.app/) |
-| sortable | Sortable component with dnd-kit. | [Link](https://github.com/sadmann7/sortable) |
-| spectrum-ui | Collection using Aceternity UI Magic UI. | [Link](https://github.com/arihantcodes/spectrum-ui) |
-| stocks | Stock Picker with Next.js charts. | [Link](https://github.com/aryanvichare/stocks) |
-| stunning-ui | Interactive Tailwind components for Vue. | [Link](https://stunningui.design) |
-| supabase-shadcn-database-example | supabase + shadcn/ui datatable | [Link](https://github.com/thisisfel1x/supabase-shadcn-database-example) |
-| supercharged-shadcn-components | Type-safe form components collection. | [Link](https://github.com/slickwit/supercharged-shadcn-components) |
-| tanstack-ui-table | Customizable table with @tanstack/table and shadcn/ui | [Link](https://github.com/drefahl/tanstack-ui-table)
-| time-picker | Simple TimePicker component. | [Link](https://github.com/openstatusHQ/time-picker) |
-| tremor | Components for charts and dashboards. | [Link](https://github.com/tremorlabs/tremor) |
-| twblocks | Website blocks based on shadcn & Radix. | [Link](https://github.com/tommyjepsen/twblocks) |
-| tweet-to-code | Twitter design recreations as code. | [Link](https://tweet-to-code.vercel.app/) |
-| ui-beats | Animated React Components collection. | [Link](https://uibeats.com) |
-| uixmat/onborda | Product tour for Next.js applications. | [Link](https://github.com/uixmat/onborda) |
-| vaul | Drawer component for React. | [Link](https://vaul.emilkowal.ski/) |
-| zoom-charts | Zoomable Charts with shadcn/ui. | [Link](https://github.com/shelwinsunga/zoom-chart-demo) |
+| 21st.dev | Open source npm for shadcn/ui components. Also: Dribble for design engineers. Install UI components via shadcn CLI, or publish your own. | [Link](https://21st.dev/) | 2024-12-06 | 2024-12-06 |
+| aceternity-ui | Copy paste the most trending react components without having to worry about styling and animations. | [Link](https://ui.aceternity.com/) | 2024-12-06 | 2024-12-06 |
+| assistant-ui | React Components for AI Chat. | [Link](https://github.com/Yonom/assistant-ui) | 2024-09-23 | 2024-09-23 |
+| autocomplete-select-shadcn-ui | Autocomplete component built with shadcn/ui and Fancy Multi Select by Maximilian Kaske. | [Link](https://www.armand-salle.fr/post/autocomplete-select-shadcn-ui) | 2024-04-07 | 2024-04-07 |
+| auto-form | A React component that automatically creates a shadcn/ui form based on a zod schema. | [Link](https://github.com/vantezzen/auto-form) | 2024-04-29 | 2024-04-29 |
+| async-select | Async Select component built with shadcn/ui with debounce search. | [Link](https://async.rdsx.dev) | 2024-07-22 | 2024-07-22 |
+| big-calendar | A modern, feature-rich calendar application with multiple viewing options built using Next.js, TypeScript, and Tailwind CSS. | [Link](https://github.com/lramos33/big-calendar) | 2025-03-08 | 2025-03-08 |
+| bundui | A collection of reusable animated components built with Tailwind CSS and Framer Motion. | [Link](https://bundui.io) | 2024-09-23 | 2024-09-23 |
+| calendar | React/shadcn full calendar like Google Calendar | [Link](https://github.com/charlietlamb/calendar) | 2024-05-03 | 2024-05-03 |
+| capture-photo | Browser-based React component for camera functionalities in web applications. | [Link](https://github.com/UretzkyZvi/capture-photo) | 2024-05-06 | 2024-05-06 |
+| clerk-elements | Composable components for building custom UIs on top of Clerk's APIs. | [Link](https://clerk.com/docs/elements/examples/shadcn-ui) | 2024-06-07 | 2024-06-07 |
+| clerk-shadcn-theme | Synchronize Clerk SignIn/SignUp components with shadcn/ui styles. | [Link](https://github.com/stormynight9/clerk-shadcn-theme) | 2024-06-07 | 2024-06-07 |
+| commerce-ui | Components, blocks and examples to build e-commerce storefronts and apps. | [Link](https://github.com/stackzero-labs/ui) | 2025-02-20 | 2025-02-20 |
+| confirm-dialog | A confirm dialog component built with shadcn/ui. | [Link](https://github.com/Aslam97/react-confirm-dialog) | 2024-07-02 | 2024-07-02 |
+| country-state-dropdown | Component built with Nextjs, Tailwindcss, shadcn/ui & Zustand. | [Link](https://github.com/Jayprecode/country-state-dropdown) | 2024-02-22 | 2024-02-22 |
+| cult-ui | Curated set of animated shadcn-style React components. | [Link](https://www.cult-ui.com/) | 2024-05-29 | 2024-05-29 |
+| credenza | Ready-made responsive modal component for shadcn/ui. | [Link](https://github.com/redpangilinan/credenza) | 2024-06-07 | 2024-06-07 |
+| crypto-charts | Crypto charts made for shadcn/ui using PythNetwork. | [Link](https://github.com/jstnw10/crypto-charts) | 2024-07-16 | 2024-07-16 |
+| date-range-picker-for-shadcn | Multi-month views, text entry, preset ranges, responsive design, and date range comparisons. | [Link](https://github.com/johnpolacek/date-range-picker-for-shadcn) | 2024-04-29 | 2024-04-29 |
+| date-time-picker-shadcn | Datetime Picker for shadNext Project. | [Link](https://shadcn-datetime-picker.vercel.app) | 2024-07-16 | 2024-07-16 |
+| date-time-range-picker-shadcn | Fully featured date-time range picker with multi-month views, timezone support, preset ranges, and modular components for date and time selection. | [Link](https://date-time-range-picker.vercel.app/) | 2025-03-08 | 2025-03-08 |
+| datetime-picker | Datetime picker with timezone support, min/max dates, and month/year selection. | [Link](https://shadcn-datetime-picker-xi.vercel.app) | 2024-07-16 | 2024-07-16 |
+| dnd-dashboard | Dashboard with drop-to-swap layouts using Next.js, shadcn/ui, and swapy. | [Link](https://github.com/olliethedev/dnd-dashboard) | 2024-10-17 | 2024-10-17 |
+| downshift-shadcn-combobox | Combobox/autocomplete component built with shadcn/ui and Downshift. | [Link](https://github.com/TheOmer77/downshift-shadcn-combobox) | 2024-06-27 | 2024-06-27 |
+| drag-to-resize-sidebar | Extended shadcn/ui sidebar component with persisted state drag-to-resize functionality. | [Link](https://github.com/lumpinif/drag-to-resize-sidebar) | 2024-11-21 | 2024-11-21 |
+| druid/ui | Intercom inspired AI chatbot and UI components built on shadcn/ui. | [Link](https://druidui.com/) | 2024-11-21 | 2024-11-21 |
+| dy-comps | shacn/ui & Framer Motion React components — flexible, responsive & easy to drop into any project. | [Link](https://dycomps.oimmi.com/) | 2025-03-08 |
+| echo-editor | Modern WYSIWYG rich-text editor based on tiptap and shadcn/ui. | [Link](https://github.com/Seedsa/echo-editor) | 2024-06-07 |
+| edil-ozi | React components with Gsap, framer motion, and tailwind. | [Link](https://edilozi.pro/) | 2024-06-27 |
+| emblor | Customizable, accessible tag input component with shadcn/ui. | [Link](https://github.com/JaleelB/emblor) | 2024-04-29 |
+| enhanced-button | Enhanced version of the default shadcn-button component. | [Link](https://github.com/jakobhoeg/enhanced-button) | 2024-04-29 |
+| extend-ui | Reusable components built on shadcn/ui for web applications. | [Link](https://www.extend-ui.com/) | 2024-11-28 |
+| fancy-area | Textarea with @mention support inspired by GitHub's PR comment section. | [Link](https://craft.mxkaske.dev/post/fancy-area) | 2024-06-27 |
+| fancy-box | GitHub PR label selector-inspired Combobox with radix-ui components. | [Link](https://craft.mxkaske.dev/post/fancy-box) | 2024-07-11 |
+| fancy-multi-select | Multi Select Component inspired by campsite.design and cal.com. | [Link](https://craft.mxkaske.dev/post/fancy-multi-select) | 2024-04-29 |
+| fancy-switch | Fancy switch component built with shadcn/ui. | [Link](https://github.com/Aslam97/react-fancy-switch) | 2024-07-11 |
+| farmui | Styled and animated component library with npm package support. | [Link](https://farmui.com) | 2024-06-08 |
+| file-uploader | File uploader with shadcn/ui and react-dropzone. | [Link](https://github.com/sadmann7/file-uploader) | 2024-06-07 |
+| file-vault | File upload component for React. | [Link](https://github.com/ManishBisht777/file-vault) | 2024-06-07 |
+| floating-dragable-card | Dragable and resizable card using shadcn/ui elements. | [Link](https://github.com/nishansanjuka/react-drag-card) | 2024-11-13 |
+| fusion-ui | Library combining shadcn/ui and MagicUI. | [Link](https://github.com/nyxb-ui/ui) | 2024-07-02 |
+| gluestack-ui | React & React Native Components with Tailwind CSS. | [Link](https://gluestack.io) | 2024-11-08 |
+| ibelick/background-snippet | Ready to use collection of modern background snippets. | [Link](https://bg.ibelick.com/) | 2024-06-09 |
+| image-upload-shadcn | Image upload component. | [Link](https://github.com/kushagrasarathe/image-upload-shadcn) | 2024-10-22 |
+| indie-ui | UI components with variants. | [Link](https://github.com/Ali-Hussein-dev/indie-ui) | 2024-06-07 |
+| inspira-ui | UI components for animated interfaces in Vue/NuxtJS. | [Link](https://inspira-ui.com/) | 2024-10-22 |
+| junwen-k/ui-x | Additional beautifully designed components that you can copy and paste into your apps. Accessible. Customizable. Open Source. | [Link](https://ui-x.junwen-k.dev/) | 2025-02-03 |
+| kokonut-ui | Free Modern and Customizable components for Next.js. | [Link](https://kokonut.dev/) | 2024-11-08 |
+| launch-ui | Landing page components with React, Shadcn/ui and Tailwind. | [Link](https://www.launchuicomponents.com/) | 2024-11-12 |
+| lingua-time | Smart datetime picker with natural language input. | [Link](https://github.com/nainglinnkhant/lingua-time) | 2024-10-22 |
+| linked-chart | Chart component linked with data-table. | [Link](https://github.com/ardasisbot/linked-chart) | 2025-02-03 |
+| lukacho-ui | Next Generation UI Components. | [Link](https://ui.lukacho.com/components) | 2024-07-02 |
+| manfromexistence-ui | Components to build beautiful designs. | [Link](https://github.com/manfromexistence/ui) | 2024-12-26 |
+| magicui | React components for landing pages with tailwindcss + framer motion. | [Link](https://magicui.design) | 2024-04-25 |
+| maily.to | Notion-like powerful email editor. | [Link](https://github.com/arikchakma/maily.to) | 2024-06-15 |
+| minimal-tiptap | Minimal WYSIWYG editor with shadcn/ui and tiptap. | [Link](https://github.com/Aslam97/shadcn-minimal-tiptap) | 2024-06-22 |
+| mixcnui | Collection of animated components for Nextjs. | [Link](https://github.com/taqui-786/mixcnui) | 2024-07-07 |
+| multi-selection | Managing multi-selection functionality with highlighter. | [Link](https://github.com/sherifawad/multi-selection-with-add-remove) | 2025-01-21 |
+| mynaui | TailwindCSS and shadcn/ui UI Kit for Figma and React. | [Link](https://mynaui.com/) | 2024-06-22 |
+| neobrutalism-components | Neobrutalism-styled Tailwind React and shadcn/ui components. | [Link](https://github.com/ekmas/neobrutalism-components) | 2024-04-07 |
+| nextjs-components | Next.js components with TypeScript and shadcn/ui. | [Link](https://components.bridger.to/) | 2024-06-07 |
+| nextjs-dnd | Sortable Drag and Drop with Next.js and dnd-kit. | [Link](https://github.com/sujjeee/nextjs-dnd) | 2024-04-09 |
+| nextjs-link-pagination | Pagination using Nextjs Links and search params. | [Link](https://shadcn-next-link-pagination.vercel.app) | 2024-07-30 |
+| nextjs-multi-image-upload | Compact, responsive file uploader with shadcn/ui, React Hook Form, and cloud support (S3/R2). | [Link](https://github.com/jacksonkasi0/nextjs-multi-image-upload) | 2025-02-23 |
+| next-shadcn-dashboard-starter | Admin Dashboard Starter with Nextjs 14 and Shadcn UI. | [Link](https://github.com/Kiranism/next-shadcn-dashboard-starter) | 2024-06-06 |
+| next-stepper | Dynamic multi-step form with Next.js and zustand. | [Link](https://github.com/ebulku/next-stepper) | 2024-11-25 |
+| novel | Notion-style WYSIWYG editor with AI-powered autocompletion. | [Link](https://github.com/steven-tey/novel) | 2024-06-11 |
+| number-flow | React component for number transitions and formatting. | [Link](https://number-flow.barvian.me/) | 2024-10-17 |
+| origin-ui | Beautiful UI components with Tailwind CSS and Next.js. | [Link](https://originui.com/) | 2024-10-28 |
+| password-input | shadcn/ui custom password input. | [Link](https://gist.github.com/mjbalcueva/b21f39a8787e558d4c536bf68e267398) | 2024-03-28 |
+| payment-gateways | Integration of payment gateways with Next.js 14. | [Link](https://github.com/PremPrakashCodes/payment-gateways) | 2024-08-05 |
+| phone-input-shadcn-ui | Custom phone number component with shadcn/ui. | [Link](https://www.armand-salle.fr/post/phone-input-shadcn-ui) | 2024-06-07 |
+| planner | Adaptable scheduling component for React. | [Link](https://github.com/UretzkyZvi/planner) | 2024-04-29 |
+| plate | AI-powered rich-text editor. | [Link](https://github.com/udecode/plate) | 2024-03-21 |
+| plate-select-editor | Rich multi-select editor. | [Link](https://platejs.org/docs/multi-select) | 2024-11-28 |
+| pqoqubbw | Open-source animated icons collection. | [Link](https://icons.pqoqubbw.dev/) | 2024-11-21 |
+| pricing-page-shadcn | Customizable pricing page with Next.js 14. | [Link](https://github.com/m4nute/pricing-page-shadcn) | 2024-04-07 |
+| progress-button | Extended button component with progress UX. | [Link](https://github.com/tomredman/ProgressButton) | 2024-07-10 |
+| react-dnd-kit-tailwind-shadcn-ui | Accessible kanban board with dnd-kit. | [Link](https://github.com/Georgegriff/react-dnd-kit-tailwind-shadcn-ui) | 2024-03-27 |
+| react-highlight-popover | Headless component for text selection popovers. | [Link](https://react-highlight-popover.omsimos.com) | 2024-10-03 |
+| react-pdf-flipbook-viewer | PDF flipbook viewer with zoom and fullscreen. | [Link](https://github.com/mohitkumawat310/react-pdf-flipbook-viewer) | 2024-12-26 |
+| react-select | React-select library with shadcn styling. | [Link](https://gist.github.com/ilkou/7bf2dbd42a7faf70053b43034fc4b5a4) | 2024-07-22 |
+| recursive-dnd-kanban-board | Recursive drag and drop kanban board. | [Link](https://github.com/mehrdadrafiee/recursive-dnd-kanban-board) | 2024-10-03 |
+| roadmap-ui | Components for interactive roadmaps. | [Link](https://github.com/haydenbleasel/roadmap-ui) | 2024-12-26 |
+| search-address | Interactive address search using OpenStreetMap. | [Link](https://github.com/UretzkyZvi/search-address) | 2024-05-07 |
+| shadcn-address-autocomplete | Address autocomplete with Google Places API. | [Link](https://github.com/NiazMorshed2007/shadcn-address-autocomplete) | 2024-07-10 |
+| shadcn-admin | Admin Dashboard UI with shadcn/ui and Vite. | [Link](https://github.com/satnaing/shadcn-admin) | 2024-12-27 |
+| shadcn-blocks | Official pre-made customizable components. | [Link](https://ui.shadcn.com/blocks) | 2024-03-27 |
+| shadcn-blocks-com | Hundreds of extra blocks built with shadcn/ui. | [Link](https://www.shadcnblocks.com) | 2025-02-23 |
+| shadcn-cal | Cal.com monthly calendar replica with shadcn/ui. | [Link](https://shadcn-cal-com.vercel.app/?date=2024-04-29) | 2024-05-03 |
+| shadcn-calendar-heatmap | Modern calendar heatmap alternative. | [Link](https://shadcn-calendar-heatmap.vercel.app/) | 2024-07-02 |
+| shadcn-calendar-component | Calendar date picker component. | [Link](https://github.com/sersavan/shadcn-calendar-component) | 2024-07-02 |
+| shadcn-chat | Customizable chat component. | [Link](https://github.com/jakobhoeg/shadcn-chat) | 2024-04-29 |
+| shadcn-carousel-testimonials | Carousel Testimonials component. | [Link](https://github.com/johanguse/shadcn-carousel-testimonials) | 2024-07-16 |
+| shadcn-chatbot-kit | Customizable chatbot components. | [Link](https://shadcn-chatbot-kit.vercel.app/) | 2024-12-27 |
+| shadcn-color-picker | Color picker with react-color. | [Link](https://shadcn-color-picker.vercel.app/) | 2024-09-23 |
+| shadcn-cookies | Sleek and flexible cookie consent component, designed with shadcn/ui | [Link](https://shadcn-cookies.vercel.app/) | 2025-02-06 |
+| shadcn-cookie-consent | Customizable cookie consent component. | [Link](https://github.com/r2hu1/shadcn-cookie-consent) | 2024-10-17 |
+| shadcn-country-dropdown | ISO 3166 country selector dropdown. | [Link](https://shadcn-country-dropdown.vercel.app/) | 2024-12-27 |
+| shadcn-data-table-advanced-col-opions | DataTable with column resizing. | [Link](https://github.com/danielagg/shadcn-data-table-advanced-col-opions) | 2024-04-07 |
+| shadcn-date-picker | Advanced date picker with various features. | [Link](https://date-picker.luca-felix.com) | 2024-07-25 |
+| shadcn-drag-and-drop-sort | Drag-and-drop sortable list of pills of different widths using dnd-kit. | [Link](https://github.com/crystaltai/shadcn-drag-and-drop) | 2025-02-03 |
+| shadcn-drag-table | Drag-and-drop table component. | [Link](https://github.com/zenoncao/shadcn-drag-table) | 2024-02-22 |
+| shadcn-dropzone | File upload component using React-Dropzone, built with accessibility in mind. | [Link](https://github.com/janglad/shadcn-dropzone) | 2025-01-13 |
+| shadcn-editor | Lexical editor with shadcn theme. | [Link](https://github.com/htmujahid/shadcn-editor) | 2024-11-08 |
+| shadcn-extends | Collection of shadcn/ui components. | [Link](https://github.com/lucioew28/extends) | 2024-06-07 |
+| shadcn-extension | Open-source component collection. | [Link](https://github.com/BelkacemYerfa/shadcn-extension) | 2024-06-07 |
+| shadcn-iconpicker | React/shadcn simple icon picker using lucide icons. | [Link](https://icon-picker.alan-courtois.fr/) | 2025-02-20 |
+| shadcn-image-cropper | Image cropper with react-image-crop. | [Link](https://github.com/sujjeee/shadcn-image-cropper) | 2024-11-08 |
+| shadcn-linear-combobox | Linear-style task priority combobox. | [Link](https://github.com/damianricobelli/shadcn-linear-combobox) | 2024-04-25 |
+| shadcn-location-picker | Simple google maps location picker. | [Link](https://github.com/brielov/shadcn-location-picker) | 2025-03-04 |
+| shadcn-multi-select-component | Multi-select component. | [Link](https://github.com/sersavan/shadcn-multi-select-component) | 2024-06-07 |
+| shadcn-number-scrubber | Draggable numeric input component. | [Link](https://github.com/camwebby/shadcn-react-number-scrubber) | 2025-01-07 |
+| shadcn-packaged | This is an npm package that exports all shadcn/ui components without the need for a CLI, designed for ease of use. | [Link](https://github.com/anuoua/shadcn-packaged) | 2025-02-27 |
+| shadcn-phone-input-2 | Phone input with libphonenumber-js. | [Link](https://github.com/damianricobelli/shadcn-phone-input) | 2024-06-07 |
+| shadcn-phone-input | Phone input with country validation. | [Link](https://github.com/omeralpi/shadcn-phone-input) | 2024-03-27 |
+| shadcn-pricing-page | Responsive pricing component with toggles. | [Link](https://github.com/aymanch-03/shadcn-pricing-page) | 2024-03-08 |
+| shadcn-spinner | Spinner component. | [Link](https://github.com/allipiopereira/shadcn-spinner) | 2024-12-09 |
+| shadcn-stepper | Complete stepper component. | [Link](https://github.com/damianricobelli/shadcn-stepper) | 2024-04-25 |
+| shadcn-table-maker | Tool for creating dynamic tables. | [Link](https://shadcn-table-maker.vercel.app/) | 2024-12-09 |
+| shadcn-table-v2 | Table with server-side features. | [Link](https://github.com/sadmann7/shadcn-table) | 2024-03-27 |
+| shadcn-timeline | Customizable timeline component. | [Link](https://github.com/timDeHof/shadcn-timeline) | 2024-06-22 |
+| shadcn-timeline-2 | Alternative timeline component. | [Link](https://timeline.rilcy.app) | 2024-11-08 |
+| shadcn-tiptap | Custom Tiptap editor extensions. | [Link](https://github.com/NiazMorshed2007/shadcn-tiptap) | 2024-11-08 |
+| shadcn-tree-view | Hierarchical data component. | [Link](https://github.com/mrlightful/shadcn-tree-view) | 2024-09-23 |
+| shadcn-ui-blocks | Collection of responsive UI blocks. | [Link](https://shadcn-ui-blocks.vercel.app/) | 2024-06-15 |
+| shadcn-ui-expansions | Additional useful components. | [Link](https://github.com/hsuanyi-chou/shadcn-ui-expansions) | 2024-06-07 |
+| shadcn-ui-sidebar | Retractable responsive sidebar. | [Link](https://github.com/salimi-my/shadcn-ui-sidebar) | 2024-05-03 |
+| shadcn-ui-templates | Free & Premium templates collection. | [Link](https://shadcnui-templates.com) | 2024-09-18 |
+| shaduxe-ui | Component variants for shadcn/ui. | [Link](https://ui.shaduxe.com) | 2024-12-27 |
+| simple-ai | Components and blocks to easily build AI apps | [Link](https://simple-ai.dev) | 2025-01-21 |
+| simplekit | Wallet and account component for Wagmi. | [Link](https://github.com/vaunblu/SimpleKit) | 2024-09-18 |
+| skiper-ui | Stand out from others with this crazzy ui library built with shad-cn cli | [Link](https://skiper-ui.com/) | 2025-02-03 |
+| solanauth | Solana wallet authentication modal. | [Link](https://solanauth.vercel.app/) | 2024-11-25 |
+| sortable | Sortable component with dnd-kit. | [Link](https://github.com/sadmann7/sortable) | 2024-04-09 |
+| spectrum-ui | Collection using Aceternity UI Magic UI. | [Link](https://github.com/arihantcodes/spectrum-ui) | 2024-11-25 |
+| stocks | Stock Picker with Next.js charts. | [Link](https://github.com/aryanvichare/stocks) | 2024-07-07 |
+| stunning-ui | Interactive Tailwind components for Vue. | [Link](https://stunningui.design) | 2024-10-22 |
+| supabase-shadcn-database-example | supabase + shadcn/ui datatable | [Link](https://github.com/thisisfel1x/supabase-shadcn-database-example) | 2024-12-30 |
+| supercharged-shadcn-components | Type-safe form components collection. | [Link](https://github.com/slickwit/supercharged-shadcn-components) | 2024-11-25 |
+| tanstack-ui-table | Customizable table with @tanstack/table and shadcn/ui | 2025-02-27 |
+| time-picker | Simple TimePicker component. | [Link](https://github.com/openstatusHQ/time-picker) | 2024-04-29 |
+| tremor | Components for charts and dashboards. | [Link](https://github.com/tremorlabs/tremor) | 2024-06-15 |
+| twblocks | Website blocks based on shadcn & Radix. | [Link](https://github.com/tommyjepsen/twblocks) | 2024-11-25 |
+| tweet-to-code | Twitter design recreations as code. | [Link](https://tweet-to-code.vercel.app/) | 2024-12-26 |
+| ui-beats | Animated React Components collection. | [Link](https://uibeats.com) | 2024-09-23 |
+| uixmat/onborda | Product tour for Next.js applications. | [Link](https://github.com/uixmat/onborda) | 2024-06-07 |
+| vaul | Drawer component for React. | [Link](https://vaul.emilkowal.ski/) | 2024-06-07 |
+| zoom-charts | Zoomable Charts with shadcn/ui. | [Link](https://github.com/shelwinsunga/zoom-chart-demo) | 2024-07-16 |
 
 ## Plugins and Extensions
 
-| Name | Description | Link |
-|-----------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| chat-with-youtube                       | A chrome extension is designed to give you the ability to efficiently summarize videos, easily search for specific parts, and enjoy additional useful features. | [Link](https://chat-with-youtube.vercel.app/ )                                               |
-| designgui                               | A Chrome Browser Extension for managing colors in CSS Variables.                                             | [Link](https://www.designgui.io/)                                                          |
-| raycast-shadcn                          | Raycast extension to Browse shadcn/ui documentation, components, and examples.                               | [Link](https://www.raycast.com/luisFilipePT/shadcn-ui)                                     |
-| shadcn-hsl-preview                      | shadcn HSL Preview extension for Visual Studio Code.                                                         | [Link](https://marketplace.visualstudio.com/items?itemName=dexxiez.shadcn-color-preview)   |
-| shadcn-ui                               | Add components from shadcn/ui directly from VS Code.                                                         | [Link](https://marketplace.visualstudio.com/items?itemName=SuhelMakkad.shadcn-ui)          |
-| shadcn/ui Components Manager            | A plugin for Jetbrain products. It allows you to manage your shadcn/ui components across Svelte, React, Vue, and Solid frameworks with this plugin. Simplify tasks like adding, removing, and updating components. | [Link](https://plugins.jetbrains.com/plugin/23479-shadcn-ui-components-manager )            |
-| vscode-shadcn-svelte                    | VS Code extension for shadcn/ui components in Svelte projects.                                               | [Link](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-svelte&ssr=false#overview) |
-| vscode-shadcn-ui-snippets               | Easily import and use shadcn-ui components with ease using snippets within VSCode. Just type cn or shadcn in your jsx/tsx file and you will get a list of all the components to choose from. | [Link](https://marketplace.visualstudio.com/items?itemName=VeroXyle.shadcn-ui-snippets  )    |
-| vscode-shadcn-vue                       | Extension for integrating shadcn/ui components into Vue.js projects.                                         | [Link](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-vue)   |
+| Name | Description | Link | Date |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------| ------- |
+| chat-with-youtube | A chrome extension is designed to give you the ability to efficiently summarize videos, easily search for specific parts, and enjoy additional useful features. | [Link](https://chat-with-youtube.vercel.app/ ) | 2024-06-07 |
+| designgui | A Chrome Browser Extension for managing colors in CSS Variables. | [Link](https://www.designgui.io/) | 2024-09-05 |
+| raycast-shadcn | Raycast extension to Browse shadcn/ui documentation, components, and examples. | [Link](https://www.raycast.com/luisFilipePT/shadcn-ui) | 2024-06-05 |
+| shadcn-hsl-preview | shadcn HSL Preview extension for Visual Studio Code. | [Link](https://marketplace.visualstudio.com/items?itemName=dexxiez.shadcn-color-preview) | 2024-09-05 |
+| shadcn-ui | Add components from shadcn/ui directly from VS Code. | [Link](https://marketplace.visualstudio.com/items?itemName=SuhelMakkad.shadcn-ui) | 2024-03-08 |
+| shadcn/ui Components Manager | A plugin for Jetbrain products. It allows you to manage your shadcn/ui components across Svelte, React, Vue, and Solid frameworks with this plugin. Simplify tasks like adding, removing, and updating components. | [Link](https://plugins.jetbrains.com/plugin/23479-shadcn-ui-components-manager ) | 2024-03-28 |
+| vscode-shadcn-svelte | VS Code extension for shadcn/ui components in Svelte projects. | [Link](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-svelte&ssr=false#overview) | 2024-03-28 |
+| vscode-shadcn-ui-snippets | Easily import and use shadcn-ui components with ease using snippets within VSCode. Just type cn or shadcn in your jsx/tsx file and you will get a list of all the components to choose from. | [Link](https://marketplace.visualstudio.com/items?itemName=VeroXyle.shadcn-ui-snippets  ) | 2024-06-05 |
+| vscode-shadcn-vue | Extension for integrating shadcn/ui components into Vue.js projects. | [Link](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-vue) | 2024-03-28 |
 
 ## Colors and Customizations
 
-| Name                                   | Description                                                                                                  | Link                                                                                 |
-|----------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| 10000+Themes for shadcn/ui             | 10000+ Themes for shadcn/ui.                                                                                 | [Link](https://ui.jln.dev/)                                                                |
-| dizzy                                  | Bootstrap a new Next or Vite project with shadcn/ui. Customize font, icons, colors, spacing, radii, and shadows. | [Link](https://dizzy.systems)                                                        |
-| ewgenius/ui                            | Create custom themes for shadcn/ui effortlessly using vibrant palettes from Radix Colors.                    | [Link](https://ui.ewgenius.me/shadcn-radix-colors)                                         |
-| gradient-picker                        | Fancy Gradient Picker built with shadcn/ui, Radix UI, and Tailwind CSS.                                      | [Link](https://github.com/Illyism/gradient-picker)                                         |
-| navnote/rangeen                        | Tool that helps you to create a colour palette for your website.                                             | [Link](https://github.com/navnote/rangeen)                                                 |
-| shadesigner.com                        | A shadcn/ui Palette Generator & Theme Designer with a beautiful interface.                                   | [Link](https://shadesigner.com)                                                            |
-| shadcn-ui-customizer                   | POC - shadcn/ui themes with color pickers.                                                                   | [Link](https://github.com/Railly/shadcn-ui-customizer)                                     |
-| shadcn theme editor                    | Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects. | [Link](https://github.com/programming-with-ia/shadcn-theme-editor/)                          |
-| ui-colorgen                            | An application designed to assist you with color configuration of shadcn/ui.                                 | [Link](https://ui-colorgen.vercel.app/)                                                      |
-| zippy starter's shadcn/ui theme generator | Easily create custom themes from a single colour that you can copy and paste into your apps.                 | [Link](https://zippystarter.com/tools/shadcn-ui-theme-generator)                             |
+| Name                                   | Description                                                                                                  | Link                                                                                 | Date |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------| ------- |
+| 10000+Themes for shadcn/ui | 10000+ Themes for shadcn/ui. | [Link](https://ui.jln.dev/) | 2024-02-22 |
+| dizzy | Bootstrap a new Next or Vite project with shadcn/ui. Customize font, icons, colors, spacing, radii, and shadows. | [Link](https://dizzy.systems) | 2024-06-05 |
+| ewgenius/ui | Create custom themes for shadcn/ui effortlessly using vibrant palettes from Radix Colors. | [Link](https://ui.ewgenius.me/shadcn-radix-colors) | 2024-10-11 |
+| gradient-picker | Fancy Gradient Picker built with shadcn/ui, Radix UI, and Tailwind CSS. | [Link](https://github.com/Illyism/gradient-picker) | 2024-03-08 |
+| navnote/rangeen | Tool that helps you to create a colour palette for your website. | [Link](https://github.com/navnote/rangeen) | 2024-06-05 |
+| shadesigner.com | A shadcn/ui Palette Generator & Theme Designer with a beautiful interface. | [Link](https://shadesigner.com) | 2024-12-26 |
+| shadcn-ui-customizer | POC - shadcn/ui themes with color pickers. | [Link](https://github.com/Railly/shadcn-ui-customizer) | 2024-03-08 |
+| shadcn theme editor | Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects. | [Link](https://github.com/programming-with-ia/shadcn-theme-editor/) | 2024-08-19 |
+| ui-colorgen | An application designed to assist you with color configuration of shadcn/ui. | [Link](https://ui-colorgen.vercel.app/) | 2024-02-22 |
+| zippy starter's shadcn/ui theme generator | Easily create custom themes from a single colour that you can copy and paste into your apps. | [Link](https://zippystarter.com/tools/shadcn-ui-theme-generator) | 2024-03-13 |
 
 ## Animations
 
-| Name                  | Description                                                                                       | Link                                                |
-|-----------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------|
-| animata              | Hand-crafted ✍️ interaction animations and effects from around the internet 🛜 to copy and paste into your project. | [Link](https://animata.design)                    |
-| magicui.design       | Largest collection of open-source react components to build beautiful landing pages.               | [Link](https://magicui.design)                            |
-| motionvariants       | Beautiful Framer Motion Animations.                                                                | [Link](https://github.com/chrisabdo/motionvariants)          |
-| tailwindcss-motion   | A new simple syntax animation library. Batteries included. Infinitely configurable.                | [Link](https://rombo.co/tailwind/)                         |
+| Name                  | Description                                                                                       | Link                                                | Date |
+|-----------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------| ------- |
+| animata | Hand-crafted ✍️ interaction animations and effects from around the internet 🛜 to copy and paste into your project. | [Link](https://animata.design) | 2024-08-26 |
+| magicui.design | Largest collection of open-source react components to build beautiful landing pages. | [Link](https://magicui.design) | 2024-04-25 |
+| motionvariants | Beautiful Framer Motion Animations. | [Link](https://github.com/chrisabdo/motionvariants) | 2024-03-08 |
+| tailwindcss-motion | A new simple syntax animation library. Batteries included. Infinitely configurable. | [Link](https://rombo.co/tailwind/) | 2024-11-13 |
 
 ## Tools
 
-| Name                                | Description                                                                                                                                           | Link                                                  |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| 5devs                               | A website to get fake Brazilian data for testing purposes.                                                                                            | [Link](https://www.5devs.com.br/ )                           |
-| ai-generator-shadcn-theme           | AI Shadcn Theme Generator, The AI Shadcn Theme Generator crafts stunning, consistent themes for your shadcn/ui projects in seconds.                   | [Link](https://ipalettes.com/theme/shadcn)                   |
-| bento-hub                           | BentoHub is an application where you can create a bento grid for your GitHub profile readme.                                                          | [Link](https://github.com/amittam104/BentoHub)               |
-| cut-it                              | Link shortener built using Next.js App Router, Server Actions, Drizzle ORM, Turso, and styled with shadcn/ui.                                         | [Link](https://github.com/mehrabmp/cut-it)                   |
-| country-data-in-charts              | Globe Graph is a web app that visualizes countries' data like GDP, GDP per capita, and population in different years using many charts.               | [Link](https://globe-graph.vercel.app/)                      |
-| dev-quotes                          | A website that displays quotes from professional programmers.                                            | [Link](https://dev-quotes-six.vercel.app/)                                                                |
-| down-dev-detector                   | This app lists all the services currently down and uses Atlassian Status Page and others (soon).                                                      | [Link](https://github.com/birobirobiro/downdevdetector)      |
-| cv-forge                            | Resume builder built with @shadcn/ui, react-hook-form, and react-pdf.                                                                                 | [Link](https://cvforge.app)                                  |
-| excelkits                           | Create free downloadable Shadcn-themed chart images. Supports PNG, JPEG, WEBP, and even WEBM videos. Upload your own data for more realistic designs. | [Link](https://excelkits.com/charts)                        |
-| form-builder                        | UI-based codegen tool to easily create beautiful and type-safe @shadcn/ui forms.                                                                      | [Link](https://github.com/AlandSleman/FormBuilder)           |
-| form-builder-fast                   | Shadcn Form Builder - Build forms in minutes for free.                                                                                                | [Link](https://ui.indie-starter.dev/form-builder)            |
-| hook-again                          | A collection of shadcn/ui installable React Hooks.                                                                                                    | [Link](https://github.com/ilyichv/hookagain)                 |
-| imgsrc                              | Generate beautiful Open Graph images with zero effort.                                                                                               | [Link](https://imgsrc.io/)                                   |
-| invoify                             | An invoice generator app built using Next.js, TypeScript, and shadcn/ui.                                                                             | [Link](https://github.com/aliabb01/invoify)                  |
-| jobsync                             | JobSync is a job seekers' assistant to manage job search efficiently.                                                                                 | [Link](https://github.com/Gsync/jobsync)                     |
-| memfree                             | Open-source hybrid AI search engine, instantly get accurate answers from the internet, bookmarks, notes, and docs. Built using Next.js and shadcn/ui. | [Link](https://github.com/memfreeme/memfree)                 |
-| myinstants                          | The largest instant sound buttons website in Brazil!                                                                                                 | [Link](https://www.myinstants.xyz/)                          |
-| opensearch-ai                       | SearchGPT/Perplexity clone but personalized for you.                                                                                                 | [Link](https://github.com/supermemoryai/opensearch-ai)       |
-| pagegen.ai                          | An AI Page Generator with Claude AI, React, and shadcn/ui. Generate web pages from text, screenshots, and templates with one click.                  | [Link](https://pagegen.ai)                                   |
-| pastecode                           | Pastebin alternative built with TypeScript, Next.js, Drizzle, shadcn/ui, and RSC.                                                                    | [Link](https://github.com/Quorin/PasteCode.app)              |
-| postgres                            | The in-browser Postgres sandbox with AI assistance.                                                                                     | [Link](https://postgres.new/)                               |
-| proxmox-helper-scripts              | A catalog of scripts for your Proxmox VE homelab, built with the Next.js App Router and styled with shadcn/ui.                                       | [Link](https://github.com/BramSuurdje/proxmox-helper-scripts) |
-| quack-db                            | Open-source in-browser DuckDB SQL editor.                                                                                               | [Link](https://github.com/mattf96s/QuackDB)                  |
-| qualmeuip                           | Find out your IP address and test your internet speed.                                                                                            | [Link](https://www.qualmeuip.xyz/)                           |
-| shadcn-form-builder                 | Create forms with Shadcn, react-hook-form, and Zod within minutes.                                                                                   | [Link](https://shadcn-form-build.vercel.app/)                |
-| shadcn-pricing-page-generator       | The easiest way to get a React pricing page with shadcn/ui, Radix UI, and/or Tailwind CSS.                                                           | [Link](https://shipixen.com/shadcn-pricing-page)             |
-| shadcn-theme-editor                 | Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects. | [Link](https://shadcnthemeeditor.vercel.app)                 |
-| shadcn-zod-form                     | CLI tool to generate shadcn/ui forms from Zod schemas.                                                                                              | [Link](https://github.com/ilyichv/shadcn-zod-form)           |
-| sharable-form-builder               | A sharable form builder for creating forms and sharing your form link, based on shadcn/ui and Next.js.                                               | [Link](https://github.com/ayoubben18/sharable-form-builder)  |
-| someday                             | Free to host and open-source Cal.com/Calendly alternative built on Google Apps Script for Gmail users.                                               | [Link](https://github.com/rbbydotdev/someday)                |
-| tinte                               | An opinionated VS Code Theme Generator 🎨.                                                                                                          | [Link](https://tinte.railly.dev/)                            |
-| translate-app                       | Translate App using TypeScript, Tailwind CSS, NextJS, Bun, shadcn/ui, AI SDK/OpenAI, and Zod.                                                        | [Link](https://github.com/developaul/translate-app)          |
-| typelabs                            | MonkeyType-inspired typing test app built with React, shadcn, and Zustand at its core.                                                              | [Link](https://github.com/imsandeshpandey/typelabs)          |
-| ui-builder                          | A React component editor that provides a no-code, visual way to create UIs, fully compatible with shadcn/ui and custom components.                  | [Link](https://github.com/olliethedev/ui-builder)            |
-| ui-fonts                            | Test and preview fonts in real-time for all your design needs. Choose the perfect typeface with ease.                                               | [Link](https://www.uifonts.app/)                             |
-| v0                                  | Vercel's generative UI system, built on shadcn/ui and TailwindCSS, allows effortless UI generation from text prompts and/or images.                  | [Link](https://v0.dev/ )                                     |
-| vercel-status-tracker               | Track the status of all of your projects deployed via Vercel. Built with shadcn/ui and TailwindCSS.                                                 | [Link](https://vercel-status-tracker.vercel.app)             |
-| wallhaven-desktop                   | Wallhaven Wallpaper software desktop. Create a Wallhaven API-based client, a true wallpaper software.                                               | [Link](https://github.com/ErKeLost/wallhaven-desktop)        |
-| xuneix                              | A link rotation tool for enhanced admin panel security. Includes dynamic URLs, expiring tokens, customizable rotation.                              | [Link](https://xuneix.theteleporter.me/)                     |
+| Name                                | Description                                                                                                                                           | Link                                                  | Date |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------| ------- |
+| 5devs | A website to get fake Brazilian data for testing purposes. | [Link](https://www.5devs.com.br/ ) | 2024-05-31 |
+| ai-generator-shadcn-theme | AI Shadcn Theme Generator, The AI Shadcn Theme Generator crafts stunning, consistent themes for your shadcn/ui projects in seconds. | [Link](https://ipalettes.com/theme/shadcn) | 2024-12-30 |
+| bento-hub | BentoHub is an application where you can create a bento grid for your GitHub profile readme. | [Link](https://github.com/amittam104/BentoHub) | 2024-09-09 |
+| cut-it | Link shortener built using Next.js App Router, Server Actions, Drizzle ORM, Turso, and styled with shadcn/ui. | [Link](https://github.com/mehrabmp/cut-it) | 2024-06-07 |
+| country-data-in-charts | Globe Graph is a web app that visualizes countries' data like GDP, GDP per capita, and population in different years using many charts. | [Link](https://globe-graph.vercel.app/) | 2024-09-09 |
+| dev-quotes | A website that displays quotes from professional programmers. | [Link](https://dev-quotes-six.vercel.app/) | 2025-01-07 |
+| down-dev-detector | This app lists all the services currently down and uses Atlassian Status Page and others (soon). | [Link](https://github.com/birobirobiro/downdevdetector) | 2024-11-04 |
+| cv-forge | Resume builder built with @shadcn/ui, react-hook-form, and react-pdf. | [Link](https://cvforge.app) | 2024-11-04 |
+| excelkits | Create free downloadable Shadcn-themed chart images. Supports PNG, JPEG, WEBP, and even WEBM videos. Upload your own data for more realistic designs. | [Link](https://excelkits.com/charts) | 2024-12-26 |
+| form-builder | UI-based codegen tool to easily create beautiful and type-safe @shadcn/ui forms. | [Link](https://github.com/AlandSleman/FormBuilder) | 2024-06-07 |
+| form-builder-fast | Shadcn Form Builder - Build forms in minutes for free. | [Link](https://ui.indie-starter.dev/form-builder) | 2024-12-26 |
+| hook-again | A collection of shadcn/ui installable React Hooks. | [Link](https://github.com/ilyichv/hookagain) | 2024-11-04 |
+| imgsrc | Generate beautiful Open Graph images with zero effort. | [Link](https://imgsrc.io/) | 2024-05-31 |
+| invoify | An invoice generator app built using Next.js, TypeScript, and shadcn/ui. | [Link](https://github.com/aliabb01/invoify) | 2024-03-27 |
+| jobsync | JobSync is a job seekers' assistant to manage job search efficiently. | [Link](https://github.com/Gsync/jobsync) | 2024-07-17 |
+| memfree | Open-source hybrid AI search engine, instantly get accurate answers from the internet, bookmarks, notes, and docs. Built using Next.js and shadcn/ui. | [Link](https://github.com/memfreeme/memfree) | 2024-07-22 |
+| myinstants | The largest instant sound buttons website in Brazil! | [Link](https://www.myinstants.xyz/) | 2024-07-22 |
+| opensearch-ai | SearchGPT/Perplexity clone but personalized for you. | [Link](https://github.com/supermemoryai/opensearch-ai) | 2024-12-26 |
+| pagegen.ai | An AI Page Generator with Claude AI, React, and shadcn/ui. Generate web pages from text, screenshots, and templates with one click. | [Link](https://pagegen.ai) | 2024-12-26 |
+| pastecode | Pastebin alternative built with TypeScript, Next.js, Drizzle, shadcn/ui, and RSC. | [Link](https://github.com/Quorin/PasteCode.app) | 2024-06-07 |
+| postgres | The in-browser Postgres sandbox with AI assistance. | [Link](https://postgres.new/) | 2024-08-13 |
+| proxmox-helper-scripts | A catalog of scripts for your Proxmox VE homelab, built with the Next.js App Router and styled with shadcn/ui. | [Link](https://github.com/BramSuurdje/proxmox-helper-scripts) | 2024-07-16 |
+| quack-db | Open-source in-browser DuckDB SQL editor. | [Link](https://github.com/mattf96s/QuackDB) | 2024-10-03 |
+| qualmeuip | Find out your IP address and test your internet speed. | [Link](https://www.qualmeuip.xyz/) | 2024-10-03 |
+| shadcn-form-builder | Create forms with Shadcn, react-hook-form, and Zod within minutes. | [Link](https://shadcn-form-build.vercel.app/) | 2024-10-03 |
+| shadcn-pricing-page-generator | The easiest way to get a React pricing page with shadcn/ui, Radix UI, and/or Tailwind CSS. | [Link](https://shipixen.com/shadcn-pricing-page) | 2024-03-08 |
+| shadcn-theme-editor | Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects. | [Link](https://shadcnthemeeditor.vercel.app) | 2024-08-19 |
+| shadcn-zod-form | CLI tool to generate shadcn/ui forms from Zod schemas. | [Link](https://github.com/ilyichv/shadcn-zod-form) | 2024-10-03 |
+| sharable-form-builder | A sharable form builder for creating forms and sharing your form link, based on shadcn/ui and Next.js. | [Link](https://github.com/ayoubben18/sharable-form-builder) | 2024-10-12 |
+| someday | Free to host and open-source Cal.com/Calendly alternative built on Google Apps Script for Gmail users. | [Link](https://github.com/rbbydotdev/someday) | 2024-12-26 |
+| tinte | An opinionated VS Code Theme Generator 🎨. | [Link](https://tinte.railly.dev/) | 2024-10-03 |
+| translate-app | Translate App using TypeScript, Tailwind CSS, NextJS, Bun, shadcn/ui, AI SDK/OpenAI, and Zod. | [Link](https://github.com/developaul/translate-app) | 2024-07-08 |
+| typelabs | MonkeyType-inspired typing test app built with React, shadcn, and Zustand at its core. | [Link](https://github.com/imsandeshpandey/typelabs) | 2024-07-08 |
+| ui-builder | A React component editor that provides a no-code, visual way to create UIs, fully compatible with shadcn/ui and custom components. | [Link](https://github.com/olliethedev/ui-builder) | 2024-10-11 |
+| ui-fonts | Test and preview fonts in real-time for all your design needs. Choose the perfect typeface with ease. | [Link](https://www.uifonts.app/) | 2024-10-23 |
+| v0 | Vercel's generative UI system, built on shadcn/ui and TailwindCSS, allows effortless UI generation from text prompts and/or images. | [Link](https://v0.dev/ ) | 2024-03-27 |
+| vercel-status-tracker | Track the status of all of your projects deployed via Vercel. Built with shadcn/ui and TailwindCSS. | [Link](https://vercel-status-tracker.vercel.app) | 2025-01-02 |
+| wallhaven-desktop | Wallhaven Wallpaper software desktop. Create a Wallhaven API-based client, a true wallpaper software. | [Link](https://github.com/ErKeLost/wallhaven-desktop) | 2024-10-23 |
+| xuneix | A link rotation tool for enhanced admin panel security. Includes dynamic URLs, expiring tokens, customizable rotation. | [Link](https://xuneix.theteleporter.me/) | 2024-07-08 |
 
 ## Websites and Portfolios Inspirations
 
-| Name                     | Description                                                                                              | Link                                   |
-|--------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------|
-| andrewsam.xyz            | A revamped version of the popular tailwind-nextjs-starter-blog using shadcn/ui, along with a resume section and experience timeline component. | [Link](https://www.andrewsam.xyz/)            |
-| birobirobiro.dev         | A personal developer portfolio.                                                                          | [Link](https://birobirobiro.dev/)             |
-| godly                    | Astronomically good web design inspiration. Only the best of the best.                                   | [Link](https://godly.website/)                |
-| list.swajp.me            | It has never been easier to find the right projects or designs by inspiring successful people.           | [Link](https://list.swajp.me)                 |
-| Nathan's AI              | An AI Chatbot acting as a portfolio, built with shadcn/ui components.                                    | [Link](https://chat.brodin.dev)               |
-| shubhporwal.me           | An eye-catching developer portfolio, built on NextJS, GSAP, Tailwind, and React.                        | [Link](https://www.shubhporwal.me/)           |
-| swajp.me                 | A visually appealing portfolio and resource hub.                                                        | [Link](https://swajp.me)                      |
-| Windows 11 (clone)       | A sleek Windows 11 clone built with React, Next.js, Tailwind CSS, ShadCN, and Framer-Motion, featuring smooth animations, draggable windows, and a modern design system. | [Link](https://win11.oimmi.com/)    |
+| Name                     | Description                                                                                              | Link                                   | Date |
+|--------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------| ------- |
+| andrewsam.xyz | A revamped version of the popular tailwind-nextjs-starter-blog using shadcn/ui, along with a resume section and experience timeline component. | [Link](https://www.andrewsam.xyz/) | 2024-09-18 |
+| birobirobiro.dev | A personal developer portfolio. | [Link](https://birobirobiro.dev/) | 2024-07-29 |
+| godly | Astronomically good web design inspiration. Only the best of the best. | [Link](https://godly.website/) | 2024-07-29 |
+| list.swajp.me | It has never been easier to find the right projects or designs by inspiring successful people. | [Link](https://list.swajp.me) | 2024-07-29 |
+| Nathan's AI | An AI Chatbot acting as a portfolio, built with shadcn/ui components. | [Link](https://chat.brodin.dev) | 2024-11-21 |
+| shubhporwal.me | An eye-catching developer portfolio, built on NextJS, GSAP, Tailwind, and React. | [Link](https://www.shubhporwal.me/) | 2024-10-03 |
+| swajp.me | A visually appealing portfolio and resource hub. | [Link](https://swajp.me) | 2024-07-29 |
+| Windows 11 (clone) | A sleek Windows 11 clone built with React, Next.js, Tailwind CSS, ShadCN, and Framer-Motion, featuring smooth animations, draggable windows, and a modern design system. | [Link](https://win11.oimmi.com/) | 2025-02-20 |
 
 ## Platforms
 
-| Name                 | Description                                                                                                 | Link                                       |
-|----------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| anonypost           | Share your thoughts and experiences anonymously by posting on the platform. Crafted using t3-stack.         | [Link](https://github.com/avalynndev/anonypost)   |
-| bolhadev            | The quickest path to learn English is speaking it regularly. Just find someone to chat with.                | [Link](https://bolhadev.chat/)                    |
-| crept-studio        | Crept is a free Open Source project, made on top of Next.js, Tailwind CSS, and Shadcn UI. You can use it to deliver free TV shows and movies. | [Link](https://www.crept.studio)                  |
-| enjoytown           | A free anime, manga, movie, and TV-shows streaming platform. Built with Next.js, shadcn/ui.                 | [Link](https://github.com/avalynndev/enjoytown)   |
-| grade-calculator    | A grade calculator/dashboard for students, aiming to provide a better overview of academic performance.      | [Link](https://grades.nstr.dev/)                  |
-| infinitunes         | A simple music player web app built using Next.js, shadcn/ui, Tailwind CSS, Drizzle ORM, and more.           | [Link](https://github.com/rajput-hemant/infinitunes) |
-| kd                  | Ad-free Kdrama streaming app. Built with Next.js, Drizzle ORM, NeonDB, and shadcn/ui.                        | [Link](https://github.com/gneiru/kd )             |
-| memergez            | Quickly generate memes by entering text or an avatar URL, with support for many meme commands.              | [Link](https://github.com/avalynndev/memergez)    |
-| midday-components   | A collection of open-source components based on Midday features.                                            | [Link](https://midday.ai/components)              |
-| plotwist            | Easy management and reviews of your movies, series, and animes using Next.js, Tailwind CSS, Supabase, and shadcn/ui. | [Link](https://plotwist.app/en-US)               |
+| Name                 | Description                                                                                                 | Link                                       | Date |
+|----------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------| ------- |
+| anonypost | Share your thoughts and experiences anonymously by posting on the platform. Crafted using t3-stack. | [Link](https://github.com/avalynndev/anonypost) | 2024-07-17 |
+| bolhadev | The quickest path to learn English is speaking it regularly. Just find someone to chat with. | [Link](https://bolhadev.chat/) | 2024-06-04 |
+| crept-studio | Crept is a free Open Source project, made on top of Next.js, Tailwind CSS, and Shadcn UI. You can use it to deliver free TV shows and movies. | [Link](https://www.crept.studio) | 2024-12-27 |
+| enjoytown | A free anime, manga, movie, and TV-shows streaming platform. Built with Next.js, shadcn/ui. | [Link](https://github.com/avalynndev/enjoytown) | 2024-06-04 |
+| grade-calculator | A grade calculator/dashboard for students, aiming to provide a better overview of academic performance. | [Link](https://grades.nstr.dev/) | 2024-12-27 |
+| infinitunes | A simple music player web app built using Next.js, shadcn/ui, Tailwind CSS, Drizzle ORM, and more. | [Link](https://github.com/rajput-hemant/infinitunes) | 2024-06-04 |
+| kd | Ad-free Kdrama streaming app. Built with Next.js, Drizzle ORM, NeonDB, and shadcn/ui. | [Link](https://github.com/gneiru/kd ) | 2024-05-31 |
+| memergez | Quickly generate memes by entering text or an avatar URL, with support for many meme commands. | [Link](https://github.com/avalynndev/memergez) | 2024-08-26 |
+| midday-components | A collection of open-source components based on Midday features. | [Link](https://midday.ai/components) | 2024-11-21 |
+| plotwist | Easy management and reviews of your movies, series, and animes using Next.js, Tailwind CSS, Supabase, and shadcn/ui. | [Link](https://plotwist.app/en-US) | 2024-05-31 |
 
 ## Ports
 
-| Name                     | Description                                                                                                 | Link                                              |
-|--------------------------|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
-| Angular                  | Angular port of shadcn/ui.                                                                                 | [Link](https://github.com/goetzrobin/spartan)            |
-| Flutter                  | Flutter port of shadcn/ui.                                                                                 | [Link](https://github.com/nank1ro/shadcn-ui)             |
-| Franken UI               | HTML-first, framework-agnostic, beautifully designed components that you can truly copy and paste into your site. Accessible. Customizable. Open Source. | [Link](https://www.franken-ui.dev/)                     |
-| JollyUI                  | shadcn/ui compatible react aria components.                                                                | [Link](https://github.com/jolbol1/jolly-ui)              |
-| Kotlin                   | Kotlin port of shadcn/ui.                                                                                  | [Link](https://github.com/dead8309/shadcn-kotlin)        |
-| Phoenix Liveview         | Phoenix Liveview port of shadcn/ui.                                                                        | [Link](https://github.com/bluzky/salad_ui)               |
-| React Native             | React Native port of shadcn/ui.                                                                            | [Link](https://github.com/Mobilecn-UI/nativecn-ui)       |
-| React Native (recommended) | React Native port of shadcn/ui (recommended).                                                             | [Link](https://github.com/mrzachnugent/react-native-reusables) |
-| Ruby                     | Ruby port of shadcn/ui.                                                                                    | [Link](https://github.com/aviflombaum/shadcn-rails)      |
-| Solid                    | Solid port of shadcn/ui.                                                                                   | [Link](https://github.com/hngngn/shadcn-solid)           |
-| Svelte                   | Svelte port of shadcn/ui.                                                                                  | [Link](https://github.com/huntabyte/shadcn-svelte)       |
-| Swift                    | Swift port of shadcn/ui.                                                                                   | [Link](https://github.com/Mobilecn-UI/swiftcn-ui)        |
-| Sysinfocus simple/ui     | Razor component library for Blazor, inspired by shadcn/ui.                                                 | [Link](https://sysinfocus.github.io/shadcn-inspired/)    |
-| Vue                      | Vue port of shadcn/ui.                                                                                     | [Link](https://github.com/radix-vue/shadcn-vue)          |
+| Name                     | Description                                                                                                 | Link                                              | Date |
+|--------------------------|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------| ------- |
+| Angular | Angular port of shadcn/ui. | [Link](https://github.com/goetzrobin/spartan) | 2024-03-21 |
+| Flutter | Flutter port of shadcn/ui. | [Link](https://github.com/nank1ro/shadcn-ui) | 2024-06-07 |
+| Franken UI | HTML-first, framework-agnostic, beautifully designed components that you can truly copy and paste into your site. Accessible. Customizable. Open Source. | [Link](https://www.franken-ui.dev/) | 2024-06-07 |
+| JollyUI | shadcn/ui compatible react aria components. | [Link](https://github.com/jolbol1/jolly-ui) | 2024-06-07 |
+| Kotlin | Kotlin port of shadcn/ui. | [Link](https://github.com/dead8309/shadcn-kotlin) | 2024-06-07 |
+| Phoenix Liveview | Phoenix Liveview port of shadcn/ui. | [Link](https://github.com/bluzky/salad_ui) | 2024-06-07 |
+| React Native | React Native port of shadcn/ui. | [Link](https://github.com/Mobilecn-UI/nativecn-ui) | 2024-06-07 |
+| React Native (recommended) | React Native port of shadcn/ui (recommended). | [Link](https://github.com/mrzachnugent/react-native-reusables) | 2024-12-27 |
+| Ruby | Ruby port of shadcn/ui. | [Link](https://github.com/aviflombaum/shadcn-rails) | 2024-06-07 |
+| Solid | Solid port of shadcn/ui. | [Link](https://github.com/hngngn/shadcn-solid) | 2024-03-28 |
+| Svelte | Svelte port of shadcn/ui. | [Link](https://github.com/huntabyte/shadcn-svelte) | 2024-02-22 |
+| Swift | Swift port of shadcn/ui. | [Link](https://github.com/Mobilecn-UI/swiftcn-ui) | 2024-06-07 |
+| Sysinfocus simple/ui | Razor component library for Blazor, inspired by shadcn/ui. | [Link](https://sysinfocus.github.io/shadcn-inspired/) | 2024-09-09 |
+| Vue | Vue port of shadcn/ui. | [Link](https://github.com/radix-vue/shadcn-vue) | 2024-02-22 |
 
 ## Design System
 
-| Name                     | Description                                                                                                     | Link                                                                                      |
-|--------------------------|-----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-| shadcn-storybook-registry| Registry of stories for the shadcn components. Quickly get the atomic level components documented in Storybook.| [Link](https://registry.lloydrichards.dev/)                                             |
-| shadcn-ui-components     | Every component recreated in Figma.                                                                            | [Link](https://www.figma.com/community/file/1342715840824755935/shadcn-ui-components)            |
-| shadcn-ui-storybook (JheanAntunes) | All shadcn/ui components registered in the storybook by JheanAntunes.                                     | [Link](https://65711ecf32bae758b457ae34-uryqbzvojc.chromatic.com/)                               |
-| shadcn-ui-storybook (fellipeutaka) | All shadcn/ui components registered in the storybook by fellipeutaka.                                     | [Link](https://fellipeutaka-ui.vercel.app/?path=/docs/components-accordion--docs)               |
+| Name                     | Description                                                                                                     | Link                                                                                      | Date |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------| ------- |
+| shadcn-storybook-registry | Registry of stories for the shadcn components. Quickly get the atomic level components documented in Storybook. | [Link](https://registry.lloydrichards.dev/) | 2025-02-07 |
+| shadcn-ui-components | Every component recreated in Figma. | [Link](https://www.figma.com/community/file/1342715840824755935/shadcn-ui-components) | 2024-03-21 |
+| shadcn-ui-storybook (JheanAntunes) | All shadcn/ui components registered in the storybook by JheanAntunes. | [Link](https://65711ecf32bae758b457ae34-uryqbzvojc.chromatic.com/) | 2024-12-27 |
+| shadcn-ui-storybook (fellipeutaka) | All shadcn/ui components registered in the storybook by fellipeutaka. | [Link](https://fellipeutaka-ui.vercel.app/?path=/docs/components-accordion--docs) | 2024-12-27 |
 
 ## Boilerplates / Templates
 
-| Name                                    | Description                                                                                                                                                                                                                                                                                  | Link                                                              |
-|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| autoflow                               | An open source GraphRAG (Knowledge Graph) built on top of TiDB Vector, LlamaIndex, and DSPy. [Demo site](https://tidb.ai).                                                                                                                                                                   | [Link](https://github.com/pingcap/autoflow)                            |
-| browser-extension-starter-plasmo-shadcn-trpc | Browser extension starter kit featuring Plasmo, React, Shadcn, and tRPC.                                                                                                                                                                                                                    | [Link](https://github.com/poweroutlet2/browser-extension-starter-plasmo-shadcn-trpc) |
-| chadnext                               | Quick Starter Template includes Next.js 14 App Router, shadcn/ui, LuciaAuth, Prisma, Server Actions, Stripe, Internationalization, and more.                                                                                                                                                | [Link](https://github.com/moinulmoin/chadnext)                          |
-| cloudflare-saas-stack                  | An opinionated, batteries-included starter kit for quickly building and deploying SaaS products on Cloudflare.                                                                                                                                                                              | [Link](https://github.com/Dhravya/cloudflare-saas-stack)                |
-| create-tauri-core                      | A project template for creating a Tauri app with Vite, React, and Tailwind CSS.                                                                                                                                                                                                             | [Link](https://github.com/mrlightful/create-tauri-core)                 |
-| design-system-template                 | Turborepo + TailwindCSS + Storybook + shadcn/ui.                                                                                                                                                                                                                                            | [Link](https://github.com/arevalolance/design-system-template)          |
-| easy-ui                                | 50+ High Quality Open Source Website Templates built using NextJS + shadcn/ui + Tailwind CSS + Framer Motion and more.                                                                                                                                                                      | [Link](https://github.com/DarkInventor/easy-ui)                         |
-| electron-shadcn                        | Electron app template with shadcn/ui and a bunch of other libs and tools ready to use.                                                                                                                                                                                                      | [Link](https://github.com/LuanRoger/electron-shadcn)                    |
-| horizon-ai-nextjs-shadcn-boilerplate  | Premium AI NextJS & shadcn/ui Boilerplate + Stripe + Supabase + OAuth.                                                                                                                                                                                                                      | [Link](https://horizon-ui.com/boilerplate-shadcn)                       |
-| kirimase                               | A template and boilerplate for quickly starting your next project with shadcn/ui, Tailwind CSS, and Next.js.                                                                                                                                                                                | [Link](https://kirimase.dev/)                                            |
-| magicui-startup-templates              | Magic UI Startup template built using shadcn/ui + TailwindCSS + Framer Motion.                                                                                                                                                                                                              | [Link](https://magicui.design/docs/templates/startup)                   |
-| nextMotion                             | Webdev portfolio template with Nodemailer integrated for easy contact form setup. Uses shadcn/ui + TailwindCSS + Framer Motion.                                                                                                                                                                                | [Link](https://github.com/yoyocharlie/nextMotion)                       |
-| next-shadcn-dashboard-starter          | Admin Dashboard Starter with Next.js 14 and shadcn/ui.                                                                                                                                                                                                                                      | [Link](https://github.com/Kiranism/next-shadcn-dashboard-starter)       |
-| next-starter                           | A Next.js starter template packed with features like TypeScript, TailwindCSS, Next-auth, Eslint, Stripe, testing tools, and more. Jumpstart your project with efficiency and style.                                                                                                         | [Link](https://github.com/Skolaczk/next-starter)                        |
-| nextjs-mdx-blog                        | Starter template built with Contentlayer, MDX, shadcn/ui, and Tailwind CSS.                                                                                                                                                                                                                 | [Link](https://github.com/ChangoMan/nextjs-mdx-blog)                    |
-| next-js-views-template                 | An open-source collection of reusable view components like Calendar, Table, etc., built with Next.js and ShadCN. Easily copy and paste these pre-built UI elements into your project for fast, responsive, and customizable layouts.                                                        | [Link](https://next-js-views-template.vercel.app)                       |
-| next-wp                                | Headless Wordpress Starter built with the NextJS App Router and React Server Components.                                                                                                                                                                                                    | [Link](https://github.com/9d8dev/next-wp)                               |
-| onyx                                   | Full stack, batteries-included MVP Template with NextJS 14, Supabase SSR Auth & Postgres DB with CRUD operations, RBAC, Tanstack React Query, Zod Validation, MDX components, Resend, and more.                                                                                              | [Link](https://github.com/rmourey26/onyx)                               |
-| opendocs                               | Beautifully designed template that you can use for your projects for free. Accessible. Customizable. Open Source with i18n support.                                                                                                                                                        | [Link](https://opendocs.daltonmenezes.com/)                             |
-| react-vite-starter                     | React starter powered with Vite + Redux Toolkit + RTKQuery + React Router + shadcn UI and many more.                                                                                                                                                                                        | [Link](https://github.com/tejachundru/react-vite-starter)               |
-| shadcn-landing-page                    | Landing page template using shadcn/ui, React, TypeScript, and Tailwind CSS.                                                                                                                                                                                                                | [Link](https://github.com/leoMirandaa/shadcn-landing-page)              |
-| shadcn-landing-page (Vue)              | Project conversion [shadcn-vue-landing-page](https://github.com/leoMirandaa/shadcn-vue-landing-page) to Next.js - Landing page template using Nestjs, shadcn/ui, TypeScript, and Tailwind CSS.                                                                                              | [Link](https://github.com/nobruf/shadcn-landing-page)                   |
-| shadcn-nextjs-free-boilerplate         | Free & Open-source NextJS Boilerplate + ChatGPT API Dashboard Template.                                                                                                                                                                                                                     | [Link](https://github.com/horizon-ui/shadcn-nextjs-boilerplate)         |
-| shadcn-registry-template               | Template repository for building a custom component registry for shadcn/ui.                                                                                                                                                                                                                | [Link](https://github.com/vantezzen/shadcn-registry-template)           |
-| shadcn-vue-landing-page                | Landing page template using Vue, shadcn-vue, TypeScript, and Tailwind CSS.                                                                                                                                                                                                                 | [Link](https://github.com/leoMirandaa/shadcn-vue-landing-page)           |
-| shadcn-next-workflows                  | Interactive workflow builder using React Flows, Next.js, and Shadcn/ui. Create, connect, and validate custom nodes easily.                                                                                                                                                                  | [Link](https://github.com/nobruf/shadcn-next-workflows)                 |
-| supa-next-shad-auth                    | A fully responsive, fully type-safe, secure server actions, user-friendly customizable UI with best practices. Tech used: NextJS + Supabase + TypeScript + Server Actions + Zod + shadcn/ui.                                                                                                | [Link](https://github.com/Sahil-Sharma-23/supa-next-shad-auth)          |
-| t3-app-template                        | Admin template for T3 Stack and shadcn/ui.                                                                                                                                                                                                                                                 | [Link](https://github.com/gaofubin/t3-app-template)                     |
-| taxonomy                               | An open-source application built using the new router, server components, and everything new in Next.js.                                                                                                                                                                                   | [Link](https://github.com/shadcn/taxonomy)                              |
-| template-next                          | A clean Next.js template with TypeScript, TailwindCSS, Shadcn/ui, and Prettier.                                                                                                                                                                                                             | [Link](https://template-next-official.vercel.app/)                      |
-| turborepo-shadcn-ui-tailwindcss        | Turborepo starter with shadcn/ui & TailwindCSS pre-configured for shared UI components.                                                                                                                                                                                                     | [Link](https://github.com/henriqpohl/turborepo-shadcn-ui-tailwindcss)    |
-| turborepo-launchpad                    | A comprehensive monorepo boilerplate for shadcn projects using Turbo. It features a highly scalable setup ideal for developing complex applications with shared components and utilities.                                                                                                   | [Link](https://github.com/JadRizk/turborepo-launchpad)                  |
-| wordpress-plugin-boilerplate           | WordPress Plugin Boilerplate utilizing modern web technologies and tools such as React, TypeScript, SASS, TailwindCSS, Shadcn UI, Vite, Grunt.js, Storybook, HMR, and more.                                                                                                                | [Link](https://github.com/prappo/wordpress-plugin-boilerplate)          |
+| Name                                    | Description                                                                                                                                                                                                                                                                                  | Link                                                              | Date |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------| ------- |
+| autoflow | An open source GraphRAG (Knowledge Graph) built on top of TiDB Vector, LlamaIndex, and DSPy. [Demo site](https://tidb.ai). | [Link](https://github.com/pingcap/autoflow) | 2024-12-06 |
+| browser-extension-starter-plasmo-shadcn-trpc | Browser extension starter kit featuring Plasmo, React, Shadcn, and tRPC. | [Link](https://github.com/poweroutlet2/browser-extension-starter-plasmo-shadcn-trpc) | 2024-10-29 |
+| chadnext | Quick Starter Template includes Next.js 14 App Router, shadcn/ui, LuciaAuth, Prisma, Server Actions, Stripe, Internationalization, and more. | [Link](https://github.com/moinulmoin/chadnext) | 2024-04-25 |
+| cloudflare-saas-stack | An opinionated, batteries-included starter kit for quickly building and deploying SaaS products on Cloudflare. | [Link](https://github.com/Dhravya/cloudflare-saas-stack) | 2024-07-24 |
+| create-tauri-core | A project template for creating a Tauri app with Vite, React, and Tailwind CSS. | [Link](https://github.com/mrlightful/create-tauri-core) | 2024-09-23 |
+| design-system-template | Turborepo + TailwindCSS + Storybook + shadcn/ui. | [Link](https://github.com/arevalolance/design-system-template) | 2024-06-06 |
+| easy-ui | 50+ High Quality Open Source Website Templates built using NextJS + shadcn/ui + Tailwind CSS + Framer Motion and more. | [Link](https://github.com/DarkInventor/easy-ui) | 2024-08-06 |
+| electron-shadcn | Electron app template with shadcn/ui and a bunch of other libs and tools ready to use. | [Link](https://github.com/LuanRoger/electron-shadcn) | 2024-06-17 |
+| horizon-ai-nextjs-shadcn-boilerplate | Premium AI NextJS & shadcn/ui Boilerplate + Stripe + Supabase + OAuth. | [Link](https://horizon-ui.com/boilerplate-shadcn) | 2024-05-24 |
+| kirimase | A template and boilerplate for quickly starting your next project with shadcn/ui, Tailwind CSS, and Next.js. | [Link](https://kirimase.dev/) | 2024-06-11 |
+| magicui-startup-templates | Magic UI Startup template built using shadcn/ui + TailwindCSS + Framer Motion. | [Link](https://magicui.design/docs/templates/startup) | 2024-04-25 |
+| nextMotion | Webdev portfolio template with Nodemailer integrated for easy contact form setup. Uses shadcn/ui + TailwindCSS + Framer Motion. | [Link](https://github.com/yoyocharlie/nextMotion) | 2024-09-23 |
+| next-shadcn-dashboard-starter | Admin Dashboard Starter with Next.js 14 and shadcn/ui. | [Link](https://github.com/Kiranism/next-shadcn-dashboard-starter) | 2024-06-06 |
+| next-starter | A Next.js starter template packed with features like TypeScript, TailwindCSS, Next-auth, Eslint, Stripe, testing tools, and more. Jumpstart your project with efficiency and style. | [Link](https://github.com/Skolaczk/next-starter) | 2024-09-23 |
+| nextjs-mdx-blog | Starter template built with Contentlayer, MDX, shadcn/ui, and Tailwind CSS. | [Link](https://github.com/ChangoMan/nextjs-mdx-blog) | 2024-04-25 |
+| next-js-views-template | An open-source collection of reusable view components like Calendar, Table, etc., built with Next.js and ShadCN. Easily copy and paste these pre-built UI elements into your project for fast, responsive, and customizable layouts. | [Link](https://next-js-views-template.vercel.app) | 2024-11-21 |
+| next-wp | Headless Wordpress Starter built with the NextJS App Router and React Server Components. | [Link](https://github.com/9d8dev/next-wp) | 2024-11-21 |
+| onyx | Full stack, batteries-included MVP Template with NextJS 14, Supabase SSR Auth & Postgres DB with CRUD operations, RBAC, Tanstack React Query, Zod Validation, MDX components, Resend, and more. | [Link](https://github.com/rmourey26/onyx) | 2024-08-13 |
+| opendocs | Beautifully designed template that you can use for your projects for free. Accessible. Customizable. Open Source with i18n support. | [Link](https://opendocs.daltonmenezes.com/) | 2024-07-29 |
+| react-vite-starter | React starter powered with Vite + Redux Toolkit + RTKQuery + React Router + shadcn UI and many more. | [Link](https://github.com/tejachundru/react-vite-starter) | 2024-12-02 |
+| shadcn-landing-page | Landing page template using shadcn/ui, React, TypeScript, and Tailwind CSS. | [Link](https://github.com/leoMirandaa/shadcn-landing-page) | 2024-06-06 |
+| shadcn-landing-page (Vue) | Project conversion [shadcn-vue-landing-page](https://github.com/leoMirandaa/shadcn-vue-landing-page) to Next.js - Landing page template using Nestjs, shadcn/ui, TypeScript, and Tailwind CSS. | [Link](https://github.com/nobruf/shadcn-landing-page) | 2024-12-27 |
+| shadcn-nextjs-free-boilerplate | Free & Open-source NextJS Boilerplate + ChatGPT API Dashboard Template. | [Link](https://github.com/horizon-ui/shadcn-nextjs-boilerplate) | 2024-05-24 |
+| shadcn-registry-template | Template repository for building a custom component registry for shadcn/ui. | [Link](https://github.com/vantezzen/shadcn-registry-template) | 2024-09-05 |
+| shadcn-vue-landing-page | Landing page template using Vue, shadcn-vue, TypeScript, and Tailwind CSS. | [Link](https://github.com/leoMirandaa/shadcn-vue-landing-page) | 2024-06-06 |
+| shadcn-next-workflows | Interactive workflow builder using React Flows, Next.js, and Shadcn/ui. Create, connect, and validate custom nodes easily. | [Link](https://github.com/nobruf/shadcn-next-workflows) | 2024-10-29 |
+| supa-next-shad-auth | A fully responsive, fully type-safe, secure server actions, user-friendly customizable UI with best practices. Tech used: NextJS + Supabase + TypeScript + Server Actions + Zod + shadcn/ui. | [Link](https://github.com/Sahil-Sharma-23/supa-next-shad-auth) | 2024-07-02 |
+| t3-app-template | Admin template for T3 Stack and shadcn/ui. | [Link](https://github.com/gaofubin/t3-app-template) | 2024-04-25 |
+| taxonomy | An open-source application built using the new router, server components, and everything new in Next.js. | [Link](https://github.com/shadcn/taxonomy) | 2024-03-21 |
+| template-next | A clean Next.js template with TypeScript, TailwindCSS, Shadcn/ui, and Prettier. | [Link](https://template-next-official.vercel.app/) | 2024-09-24 |
+| turborepo-shadcn-ui-tailwindcss | Turborepo starter with shadcn/ui & TailwindCSS pre-configured for shared UI components. | [Link](https://github.com/henriqpohl/turborepo-shadcn-ui-tailwindcss) | 2024-06-06 |
+| turborepo-launchpad | A comprehensive monorepo boilerplate for shadcn projects using Turbo. It features a highly scalable setup ideal for developing complex applications with shared components and utilities. | [Link](https://github.com/JadRizk/turborepo-launchpad) | 2024-06-10 |
+| wordpress-plugin-boilerplate | WordPress Plugin Boilerplate utilizing modern web technologies and tools such as React, TypeScript, SASS, TailwindCSS, Shadcn UI, Vite, Grunt.js, Storybook, HMR, and more. | [Link](https://github.com/prappo/wordpress-plugin-boilerplate) | 2024-09-24 |
 
 
 ## Star History

--- a/scripts/add-dates.js
+++ b/scripts/add-dates.js
@@ -6,58 +6,80 @@ const lines = content.split('\n');
 
 const currentDate = new Date().toISOString().split('T')[0]; // e.g., 2023-10-15
 const updatedLines = [];
+let changesCount = 0;
+
+console.log(`Processing README.md with ${lines.length} lines`);
 
 let inTable = false;
 let tableHasDateColumn = false;
 let headerLineCount = 0;
+let dateColumnIndex = -1;
 
-for (const line of lines) {
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  
   // Reset table state when hitting a new section
   if (line.startsWith('## ')) {
     inTable = false;
     tableHasDateColumn = false;
     headerLineCount = 0;
+    dateColumnIndex = -1;
   }
   
   if (line.startsWith('|')) {
     if (!inTable) {
-      // First line of a new table
+      // First line of a new table (header)
       inTable = true;
       headerLineCount = 1;
       
-      // Check if the table header has a date column
+      // Check if the table header has a date column and find its index
       const parts = line.split('|').map(part => part.trim());
-      tableHasDateColumn = parts.includes('Date');
+      dateColumnIndex = parts.findIndex(part => part === 'Date');
+      tableHasDateColumn = dateColumnIndex > -1;
+      console.log(`Found table, has date column: ${tableHasDateColumn}, at index: ${dateColumnIndex}`);
     } else {
       headerLineCount++;
     }
     
-    const parts = line.split('|').map(part => part.trim());
+    const parts = line.split('|');
     
     // Skip header and separator rows
-    if (headerLineCount <= 2 || parts.some(p => p.startsWith('-'))) {
+    if (headerLineCount <= 2) {
       updatedLines.push(line);
       continue;
     }
     
     // Handle data rows
-    if (tableHasDateColumn) {
-      // Table already has a date column, check if this row needs a date
-      const lastColumn = parts[parts.length - 2]; // Get the last non-empty column
-      if (!lastColumn || lastColumn === '') {
-        // Replace the empty date with current date
-        const newLine = line.replace(/\|\s*\|$/, `| ${currentDate} |`);
+    if (tableHasDateColumn && dateColumnIndex > 0) {
+      // Check if this row needs a date
+      const dateValue = parts[dateColumnIndex].trim();
+      
+      if (!dateValue || dateValue === '') {
+        // This row needs a date
+        parts[dateColumnIndex] = ` ${currentDate} `;
+        const newLine = parts.join('|');
         updatedLines.push(newLine);
+        changesCount++;
+        console.log(`Added date to row: ${parts[1].trim()}`);
       } else {
-        updatedLines.push(line); // Keep existing date
+        // Row already has a date
+        updatedLines.push(line);
       }
     } else {
-      // Table doesn't have a date column, add one
-      updatedLines.push(line + ` ${currentDate} |`);
+      // No date column in this table
+      updatedLines.push(line);
     }
   } else {
+    // Not a table row
     updatedLines.push(line);
   }
 }
 
-fs.writeFileSync(path, updatedLines.join('\n'));
+console.log(`Made ${changesCount} changes to README.md`);
+
+if (changesCount > 0) {
+  fs.writeFileSync(path, updatedLines.join('\n'));
+  console.log('Changes written to README.md');
+} else {
+  console.log('No changes needed, file not modified');
+}

--- a/scripts/add-dates.js
+++ b/scripts/add-dates.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+
+const path = 'README.md';
+const content = fs.readFileSync(path, 'utf8');
+const lines = content.split('\n');
+
+let inTable = false;
+const currentDate = new Date().toISOString().split('T')[0]; // e.g., 2023-10-15
+const updatedLines = [];
+
+for (const line of lines) {
+  if (line.startsWith('## ')) {
+    inTable = false; // Reset when hitting a new section
+  }
+  if (line.startsWith('|')) {
+    inTable = true;
+    const parts = line.split('|').map(part => part.trim());
+    // Check for data rows (not header or separator)
+    if (parts.length === 4 && !parts[1].startsWith('-') && parts[1] !== 'Name') {
+      // Row has 3 columns (excluding empty parts at ends), append date
+      updatedLines.push(line + ` ${currentDate} |`);
+    } else {
+      updatedLines.push(line); // Leave headers, separators, or 4-column rows unchanged
+    }
+  } else {
+    inTable = false;
+    updatedLines.push(line);
+  }
+}
+
+fs.writeFileSync(path, updatedLines.join('\n'));

--- a/scripts/add-dates.js
+++ b/scripts/add-dates.js
@@ -4,26 +4,58 @@ const path = 'README.md';
 const content = fs.readFileSync(path, 'utf8');
 const lines = content.split('\n');
 
-let inTable = false;
 const currentDate = new Date().toISOString().split('T')[0]; // e.g., 2023-10-15
 const updatedLines = [];
 
+let inTable = false;
+let tableHasDateColumn = false;
+let headerLineCount = 0;
+
 for (const line of lines) {
+  // Reset table state when hitting a new section
   if (line.startsWith('## ')) {
-    inTable = false; // Reset when hitting a new section
+    inTable = false;
+    tableHasDateColumn = false;
+    headerLineCount = 0;
   }
+  
   if (line.startsWith('|')) {
-    inTable = true;
-    const parts = line.split('|').map(part => part.trim());
-    // Check for data rows (not header or separator)
-    if (parts.length === 4 && !parts[1].startsWith('-') && parts[1] !== 'Name') {
-      // Row has 3 columns (excluding empty parts at ends), append date
-      updatedLines.push(line + ` ${currentDate} |`);
+    if (!inTable) {
+      // First line of a new table
+      inTable = true;
+      headerLineCount = 1;
+      
+      // Check if the table header has a date column
+      const parts = line.split('|').map(part => part.trim());
+      tableHasDateColumn = parts.includes('Date');
     } else {
-      updatedLines.push(line); // Leave headers, separators, or 4-column rows unchanged
+      headerLineCount++;
+    }
+    
+    const parts = line.split('|').map(part => part.trim());
+    
+    // Skip header and separator rows
+    if (headerLineCount <= 2 || parts.some(p => p.startsWith('-'))) {
+      updatedLines.push(line);
+      continue;
+    }
+    
+    // Handle data rows
+    if (tableHasDateColumn) {
+      // Table already has a date column, check if this row needs a date
+      const lastColumn = parts[parts.length - 2]; // Get the last non-empty column
+      if (!lastColumn || lastColumn === '') {
+        // Replace the empty date with current date
+        const newLine = line.replace(/\|\s*\|$/, `| ${currentDate} |`);
+        updatedLines.push(newLine);
+      } else {
+        updatedLines.push(line); // Keep existing date
+      }
+    } else {
+      // Table doesn't have a date column, add one
+      updatedLines.push(line + ` ${currentDate} |`);
     }
   } else {
-    inTable = false;
     updatedLines.push(line);
   }
 }


### PR DESCRIPTION
Created a GitHub workflow and script that will automatically add dates to new resources when a PR is opened or updated.

The date will be the current date when the PR is opened or updated, not when it's merged. This is because the workflow runs on the `pull_request` event with types `[opened, synchronize]`, which means it runs when the PR is created or when new commits are pushed to it.

If someone adds a resource that already has a date column (4 columns total), the script will leave it unchanged.

ps. also ran and applied all past pr dates