### PR TITLE
Add styleseed

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@
 | spectrum-ui | Collection using Aceternity UI Magic UI. | [Link](https://github.com/arihantcodes/spectrum-ui) | 2024-11-25 |
 | stateful-button | A shadcn/ui button component that provides clear visual feedback with full accessibility support for loading/progress, success, and error states during asynchronous operations. | [Link](https://github.com/nanyx95/Stateful-Button-React) | 2025-09-06 |
 | stocks | Stock Picker with Next.js charts. | [Link](https://github.com/aryanvichare/stocks) | 2024-07-07 |
+| styleseed | Design engine that makes Claude Code and Cursor produce professional UI. 48 shadcn-style React components, 69 design rules, 11 AI slash-command skills, and swappable brand skins (Toss, Stripe, Linear, Vercel, Notion) on Tailwind CSS v4 + Radix UI. | [Link](https://github.com/bitjaru/styleseed) | 2026-04-13 |
 | supabase-shadcn-database-example | supabase + shadcn/ui datatable | [Link](https://github.com/thisisfel1x/supabase-shadcn-database-example) | 2024-12-30 |
 | supercharged-shadcn-components | Type-safe form components collection. | [Link](https://github.com/slickwit/supercharged-shadcn-components) | 2024-11-25 |
 | svelte-image-uploader | Svelte image uploader with dnd, validation and previews. | [Link](https://svelte-image-uploader.vercel.app/) | 2025-06-10 |

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@
 | spectrum-ui | Collection using Aceternity UI Magic UI. | [Link](https://github.com/arihantcodes/spectrum-ui) | 2024-11-25 |
 | stateful-button | A shadcn/ui button component that provides clear visual feedback with full accessibility support for loading/progress, success, and error states during asynchronous operations. | [Link](https://github.com/nanyx95/Stateful-Button-React) | 2025-09-06 |
 | stocks | Stock Picker with Next.js charts. | [Link](https://github.com/aryanvichare/stocks) | 2024-07-07 |
-| styleseed | Design engine with 48 shadcn-style components and swappable brand skins. | [Link](https://github.com/bitjaru/styleseed) | 2026-04-13 |
+| styleseed | Design engine with 48 shadcn-style components and swappable brand skins. | [Link](https://github.com/bitjaru/styleseed) |
 | supabase-shadcn-database-example | supabase + shadcn/ui datatable | [Link](https://github.com/thisisfel1x/supabase-shadcn-database-example) | 2024-12-30 |
 | supercharged-shadcn-components | Type-safe form components collection. | [Link](https://github.com/slickwit/supercharged-shadcn-components) | 2024-11-25 |
 | svelte-image-uploader | Svelte image uploader with dnd, validation and previews. | [Link](https://svelte-image-uploader.vercel.app/) | 2025-06-10 |

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@
 | spectrum-ui | Collection using Aceternity UI Magic UI. | [Link](https://github.com/arihantcodes/spectrum-ui) | 2024-11-25 |
 | stateful-button | A shadcn/ui button component that provides clear visual feedback with full accessibility support for loading/progress, success, and error states during asynchronous operations. | [Link](https://github.com/nanyx95/Stateful-Button-React) | 2025-09-06 |
 | stocks | Stock Picker with Next.js charts. | [Link](https://github.com/aryanvichare/stocks) | 2024-07-07 |
-| styleseed | Design engine that makes Claude Code and Cursor produce professional UI. 48 shadcn-style React components, 69 design rules, 11 AI slash-command skills, and swappable brand skins (Toss, Stripe, Linear, Vercel, Notion) on Tailwind CSS v4 + Radix UI. | [Link](https://github.com/bitjaru/styleseed) | 2026-04-13 |
+| styleseed | Design engine with 48 shadcn-style components and swappable brand skins. | [Link](https://github.com/bitjaru/styleseed) | 2026-04-13 |
 | supabase-shadcn-database-example | supabase + shadcn/ui datatable | [Link](https://github.com/thisisfel1x/supabase-shadcn-database-example) | 2024-12-30 |
 | supercharged-shadcn-components | Type-safe form components collection. | [Link](https://github.com/slickwit/supercharged-shadcn-components) | 2024-11-25 |
 | svelte-image-uploader | Svelte image uploader with dnd, validation and previews. | [Link](https://svelte-image-uploader.vercel.app/) | 2025-06-10 |


### PR DESCRIPTION
Adding **styleseed** to the Libs and Components table (alphabetically between `stocks` and `supabase-shadcn-database-example`).

**Link:** https://github.com/bitjaru/styleseed (184 stars, MIT)

A design engine built on shadcn/ui + Tailwind CSS v4 + Radix UI that makes Claude Code and Cursor produce professional UI. Includes:
- 48 shadcn-style React components
- 69 documented design rules (card hierarchy, typography scale, spacing rhythm)
- 11 AI slash-command skills for Claude Code
- Swappable brand skins: Toss, Stripe, Linear, Vercel, Notion

Thanks for maintaining this list! 🙏