### PR TITLE
ci: add weekly broken link check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,53 @@
+name: Link Check
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    name: Check all links in README
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Run lychee link checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --cache
+            --max-cache-age 1d
+            --no-progress
+            --accept '200..=299,401,403,429'
+            --max-concurrency 20
+            --timeout 30
+            README.md
+          fail: false
+
+      - name: Update or create tracking issue
+        if: steps.lychee.outputs.exit_code != 0
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create broken-links --color CC0000 --description "Automated link check found broken URLs" 2>/dev/null || true
+          existing=$(gh issue list --label broken-links --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file lychee/out.md
+            gh issue comment "$existing" --body "Link check re-ran on $(date -u +%Y-%m-%d). Report in issue body updated."
+          else
+            gh issue create --title "Broken links found in README" --label broken-links --body-file lychee/out.md
+          fi


### PR DESCRIPTION
## Summary

Adds an automated weekly GitHub Action that checks every link in `README.md` and files the broken ones in a single auto-updated issue.

**How it works:**
- Runs every Monday at 06:00 UTC (plus manual trigger via `workflow_dispatch`)
- Uses [`lychee`](https://github.com/lycheeverse/lychee-action) (the community-standard link checker — handles redirects, rate limits, caching)
- Accepts `401`, `403`, `429` as not-broken (login-required / anti-bot / rate-limit noise)
- Reports into a single labeled `broken-links` issue that gets edited-in-place each run (no issue spam)

Partial follow-up to #337. PR #478 removes the 20 already-known broken links; this workflow keeps future ones from rotting.

## Test plan

- [ ] After merge, trigger the workflow manually from the Actions tab (`workflow_dispatch`) to confirm it runs cleanly on a README with no broken links (should finish without creating an issue since #478 cleanup already landed)
- [ ] Verify the `broken-links` label gets created on first run
- [ ] On a subsequent run with a known-broken URL, verify a single issue is opened (and not re-opened on repeat runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)