### PR TITLE
fix(ci): retry add-dates push on concurrent-merge race

### DIFF
--- a/.github/workflows/add-dates.yml
+++ b/.github/workflows/add-dates.yml
@@ -27,5 +27,18 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add README.md
-          git diff --quiet && git diff --staged --quiet || git commit -m "Add dates to new resources"
-          git push
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No date changes to commit."
+            exit 0
+          fi
+          git commit -m "Add dates to new resources"
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed on attempt $attempt."
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt). Rebasing on latest main and retrying..."
+            git pull --rebase origin main
+          done
+          echo "Push still failing after 5 attempts."
+          exit 1


### PR DESCRIPTION
## Summary

The `add-dates` workflow was failing with \`! [rejected] main -> main (fetch first)\` when two PRs get merged back-to-back (e.g. #480 and #481 merged 5s apart — #480's workflow failed, #481's succeeded after picking up #480's README change).

The system was self-healing because the next merge's workflow picks up the missed date and pushes it forward, but that only works if more merges keep happening. If the failed merge is the last one of the day, the entry stays dateless overnight.

## Change

Wrap the final \`git push\` in a rebase-and-retry loop (5 attempts). If the remote advanced between our checkout and push, rebase on the latest main and try again.

## Test plan

- [ ] Merge this PR and confirm the workflow runs cleanly on its own merge
- [ ] Optionally: force the race by merging two simple PRs within a few seconds of each other — both should succeed (or the loser should retry and still push its date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)