### PR TITLE
ci: detect duplicate names and URLs in format-readme script

### DIFF
--- a/scripts/format-readme.js
+++ b/scripts/format-readme.js
@@ -42,3 +42,71 @@ try {
   console.error(`Error writing README.md: ${err.message}`);
   process.exit(1);
 }
+
+// ---- Duplicate check ----
+//
+// Secondary defense against duplicate entries across sections. The submission
+// form (src/app/api/submit-resource/route.ts) also checks duplicates, but
+// direct commits bypass it — this catches those.
+//
+// Exits non-zero if any resource name or URL appears in more than one row,
+// which fails the format-readme workflow.
+
+const duplicates = findDuplicates(updatedLines);
+if (duplicates.length > 0) {
+  console.error('\nDuplicate entries detected in README.md:');
+  for (const dup of duplicates) {
+    console.error(`  - ${dup.kind} "${dup.value}" appears in:`);
+    for (const occ of dup.occurrences) {
+      console.error(`      • ${occ.section} → "${occ.name}"`);
+    }
+  }
+  console.error('\nEach resource name and URL must be unique across the whole README.');
+  process.exit(1);
+}
+
+function findDuplicates(allLines) {
+  const byName = new Map();
+  const byUrl = new Map();
+  let currentSection = '(before first section)';
+
+  for (const line of allLines) {
+    if (line.startsWith('## ')) {
+      currentSection = line.replace(/^##\s+/, '').trim();
+      continue;
+    }
+
+    if (!line.startsWith('|') || line.match(/^\|[\s-]+\|/)) continue;
+
+    const parts = line.split('|').map(p => p.trim());
+    if (parts.length < 2) continue;
+
+    const name = parts[1];
+    // Skip header rows ("Name") and empty rows
+    if (!name || name.toLowerCase() === 'name') continue;
+
+    const nameKey = name.toLowerCase();
+    if (!byName.has(nameKey)) byName.set(nameKey, []);
+    byName.get(nameKey).push({ section: currentSection, name });
+
+    const urlMatch = line.match(/\[Link\]\(([^)]+)\)/);
+    if (urlMatch) {
+      const urlKey = urlMatch[1].toLowerCase();
+      if (!byUrl.has(urlKey)) byUrl.set(urlKey, []);
+      byUrl.get(urlKey).push({ section: currentSection, name });
+    }
+  }
+
+  const results = [];
+  for (const [key, occurrences] of byName) {
+    if (occurrences.length > 1) {
+      results.push({ kind: 'name', value: key, occurrences });
+    }
+  }
+  for (const [key, occurrences] of byUrl) {
+    if (occurrences.length > 1) {
+      results.push({ kind: 'URL', value: key, occurrences });
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary

Adds a full-README duplicate scan at the end of \`scripts/format-readme.js\`. Runs inside the existing \`format-readme\` workflow on every PR that touches README.md. Exits non-zero (and therefore fails the check) if any resource name or URL appears in more than one row.

## Why a second check?

\`src/app/api/submit-resource/route.ts\` validates duplicates at submission time — but that path is only used by the website form. Direct commits to the repo (maintainer edits, hand-crafted PRs from GitHub contributors) bypass it entirely. This is the secondary defense.

## Error output

On duplicates, the workflow log shows exactly which section and row each offender lives in, e.g.:

\`\`\`
Duplicate entries detected in README.md:
  - name "shadcn-admin" appears in:
      • Libs and Components → "shadcn-admin"
      • Boilerplates / Templates → "shadcn-admin"
  - URL "https://magicui.design" appears in:
      • Libs and Components → "magicui"
      • Animations → "magicui.design"
\`\`\`

## Order of merge

⚠️ **Merge #483 first.** That PR cleans up 4 pre-existing duplicates. If this check lands before #483, it will fail on every subsequent PR that touches README.md until #483 is in.

## Test plan

- [ ] After #483 merges, confirm this workflow passes on a no-op PR (or use workflow_dispatch).
- [ ] Temporarily add a duplicate row in a test PR → check should fail with the clear error message.

Related: #483 (cleanup), #484 (fix the form API that let these through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)