### PR TITLE
feat: autofocus search inputs and fix categories spacing

### DIFF
--- a/src/app/categories/[category]/[id]/loading.tsx
+++ b/src/app/categories/[category]/[id]/loading.tsx
@@ -42,7 +42,7 @@ export default function Loading() {
       </div>
 
       {/* Content grid */}
-      <div className="min-h-screen grid gap-6 sm:gap-8 grid-cols-1 lg:grid-cols-3">
+      <div className="grid gap-6 sm:gap-8 grid-cols-1 lg:grid-cols-3">
         {/* Left column - Preview */}
         <div className="lg:col-span-2 space-y-6 sm:space-y-8">
           <Card>

--- a/src/app/categories/[category]/loading.tsx
+++ b/src/app/categories/[category]/loading.tsx
@@ -32,7 +32,7 @@ export default function CategoryLoading() {
       </div>
 
       {/* ItemGrid skeleton - matches ItemCard structure */}
-      <div className="min-h-screen mb-6 sm:mb-8">
+      <div className="mb-6 sm:mb-8">
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {[...Array(12)].map((_, i) => (
             <div key={i} className="border p-4 space-y-0 flex flex-col h-full">

--- a/src/app/categories/loading.tsx
+++ b/src/app/categories/loading.tsx
@@ -26,7 +26,7 @@ export default function CategoriesLoading() {
       </div>
 
       {/* Grid */}
-      <div className="min-h-screen grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {[...Array(12)].map((_, i) => (
           <Card key={i} className="h-[280px] flex flex-col">
             <CardHeader className="p-4 pb-3">

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -73,7 +73,7 @@ export default async function CategoriesPage() {
         breadcrumbs={[{ label: "Categories", href: "/categories" }]}
       />
 
-      <div className="min-h-screen grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {categories.map((category) => (
           <Link
             key={category.title}

--- a/src/components/category-page-content.tsx
+++ b/src/components/category-page-content.tsx
@@ -121,7 +121,7 @@ export function CategoryPageContent({
         }
       />
 
-      <div className="min-h-screen mb-6 sm:mb-8">
+      <div className="mb-6 sm:mb-8">
         <ItemGrid
           items={currentItems}
           bookmarkedItems={bookmarkedItems}

--- a/src/components/category-page-content.tsx
+++ b/src/components/category-page-content.tsx
@@ -109,6 +109,7 @@ export function CategoryPageContent({
             </div>
             <div className="w-full max-w-md">
               <Input
+                autoFocus
                 type="text"
                 placeholder="Search within this category..."
                 value={searchQuery}

--- a/src/components/item-page-content.tsx
+++ b/src/components/item-page-content.tsx
@@ -107,7 +107,7 @@ export function ItemPageContent({
         }
       />
 
-      <div className="min-h-screen grid gap-6 sm:gap-8 grid-cols-1 lg:grid-cols-3">
+      <div className="grid gap-6 sm:gap-8 grid-cols-1 lg:grid-cols-3">
         <motion.div
           className="lg:col-span-2 space-y-6 sm:space-y-8"
           initial={{ opacity: 0, y: 20 }}

--- a/src/components/search-filter-controls.tsx
+++ b/src/components/search-filter-controls.tsx
@@ -49,6 +49,7 @@ export function SearchFilterControls({
     >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
         <Input
+          autoFocus
           type="text"
           placeholder="Search items..."
           value={searchQuery}


### PR DESCRIPTION
## Summary

- **autoFocus** on the search input in the home page (\`src/components/search-filter-controls.tsx\`) and the category page (\`src/components/category-page-content.tsx\`). Users can start typing immediately without clicking the box.
- **Remove \`min-h-screen\` from 5 grid/list wrappers.** The class was forcing the container to fill the viewport and distributing the leftover height as oversized vertical gaps between rows (categories grid) or as a huge empty strip below short lists (category detail, item detail, and their loading skeletons). With \`min-h-screen\` gone, content sits at its natural spacing (controlled by \`gap-*\` and content height).

  Affected files:
  - \`src/app/categories/page.tsx\` — category list grid (4-col)
  - \`src/app/categories/loading.tsx\` — skeleton for the above
  - \`src/components/category-page-content.tsx\` — category detail list wrapper
  - \`src/app/categories/[category]/loading.tsx\` — skeleton for the above
  - \`src/components/item-page-content.tsx\` — item detail 3-col grid
  - \`src/app/categories/[category]/[id]/loading.tsx\` — skeleton for the above

## Test plan

- [ ] Load \`/\` → search input has focus on load.
- [ ] Load \`/categories/<slug>\` → search input has focus on load.
- [ ] Load \`/categories\` → rows of cards sit close together (no huge vertical gaps between rows).
- [ ] Load a category with only a few items (e.g. \`/categories/design-system\`) → pagination sits right below cards, no big empty strip.
- [ ] Load an item detail page → preview + sidebar columns match their content height.

Verified locally via dev server + Chrome DevTools MCP on \`/categories\` and \`/categories/design-system\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)