### PR TITLE
feat: Add shadcn-motion-blocks to Animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@
 | animata | Hand-crafted ✍️ interaction animations and effects from around the internet 🛜 to copy and paste into your project. | [Link](https://animata.design) | 2024-12-27T12:56:05.000Z |
 | animate-ui | A fully animated, open-source React component distribution. Browse a list of animated primitives, components and icons you can install and use in your projects. | [Link](https://animate-ui.com/) | 2025-10-15T02:52:46.000Z |
 | motionvariants | Beautiful Framer Motion Animations. | [Link](https://github.com/chrisabdo/motionvariants) | 2024-12-27T12:56:05.000Z |
-| shadcn-motion-blocks | 35 motion-aware marketing blocks for shadcn/ui + Tailwind 4. Free trio installable via shadcn CLI; Framer Motion + Lenis baked in, respects prefers-reduced-motion. | [Link](https://componentblocks.com) |  |
+| shadcn-motion-blocks | 35 motion-aware marketing blocks for shadcn/ui + Tailwind 4. Free trio installable via shadcn CLI. Framer Motion + Lenis baked in, respects prefers-reduced-motion. | [Link](https://componentblocks.com) |  |
 | smooth-ui | Highly customizable, production-ready UI blocks for building beautiful websites and apps that look and feel the way you mean it. | [Link](https://smoothui.dev/) | 2025-10-15T03:04:19.000Z |
 | tailwindcss-motion | A new simple syntax animation library. Batteries included. Infinitely configurable. | [Link](https://rombo.co/tailwind/) | 2024-12-27T12:56:05.000Z |
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@
 | animata | Hand-crafted ✍️ interaction animations and effects from around the internet 🛜 to copy and paste into your project. | [Link](https://animata.design) | 2024-12-27T12:56:05.000Z |
 | animate-ui | A fully animated, open-source React component distribution. Browse a list of animated primitives, components and icons you can install and use in your projects. | [Link](https://animate-ui.com/) | 2025-10-15T02:52:46.000Z |
 | motionvariants | Beautiful Framer Motion Animations. | [Link](https://github.com/chrisabdo/motionvariants) | 2024-12-27T12:56:05.000Z |
+| shadcn-motion-blocks | 35 motion-aware marketing blocks for shadcn/ui + Tailwind 4. Free trio installable via shadcn CLI; Framer Motion + Lenis baked in, respects prefers-reduced-motion. | [Link](https://componentblocks.com) |  |
 | smooth-ui | Highly customizable, production-ready UI blocks for building beautiful websites and apps that look and feel the way you mean it. | [Link](https://smoothui.dev/) | 2025-10-15T03:04:19.000Z |
 | tailwindcss-motion | A new simple syntax animation library. Batteries included. Infinitely configurable. | [Link](https://rombo.co/tailwind/) | 2024-12-27T12:56:05.000Z |
 


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**
shadcn-motion-blocks is a library of 35 motion-aware marketing blocks (heroes, pricing tables, feature grids, CTAs, animated backgrounds) built specifically for shadcn/ui and Tailwind CSS v4. Every block ships as a single copy-paste React file with Framer Motion 12 and Lenis smooth scroll baked in, and respects `prefers-reduced-motion` by default. Three blocks are free and installable via the shadcn CLI (`npx shadcn add ...`). They are `bg-aurora-mesh`, `magnetic-buttons`, and `text-shimmer`, letting anyone evaluate the motion and accessibility patterns before committing to the full pack.

## Which section does it belong to?

- [x] Animations

(Also a reasonable fit for Libs and Components. Happy to move if reviewers prefer.)

## Additional details

- Website: https://componentblocks.com
- Live previews of all 35 blocks render on the site itself.
- Built on Next.js 16, React 19, Tailwind 4, Framer Motion 12, and Lenis.
- Per-route preview pages ensure each block iframe ships only its own JS chunk, so there is no shared client bundle bloat.
- Honest disclosure: 3 blocks free, full pack is a one-time €19 purchase. Including this because recent merges (#509 chatdeck-shadcn-saas-landing-template, others) show paid resources with a free entry point are accepted. Happy to defer to maintainer judgment.

## Checklist

- [x] I verified that the resource is listed in alphabetical order within its section (between `motionvariants` and `smooth-ui`).
- [x] I checked that the resource is not already listed.
- [x] I provided a clear and concise description of the resource.
- [x] I included a valid and working link to the resource.
- [x] I assigned the correct section to the resource.