### PR TITLE
feat: add 7ovr to the Registries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@
 
 | Name | Description | Link | Date |
 | ------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ---------- |
+| 7ovr | Free, production-ready blocks built on Base UI for marketing and application UIs. Copy, paste, and ship in minutes. | [Link](https://7ovr.com/?utm_source=awesome-shadcn-ui&utm_medium=referral&utm_campaign=directory) |  |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |


### PR DESCRIPTION
**What is it?**
> 7ovr is a free registry of production-ready shadcn/ui blocks built on Base UI, spanning marketing and application UIs. Add the registry to your `components.json` and install any block with the shadcn CLI. Free blocks are MIT-0 (free for personal and commercial use, no attribution).

**Which section does it belong to?**
- Registries

**Additional details (optional)**
> Live preview + code for every block at https://7ovr.com/blocks . Built on Base UI to match shadcn's current default style, so blocks install clean into fresh shadcn projects.

## Checklist
- [x] Listed in alphabetical order within its section (7ovr sorts to the top of Registries)
- [x] Not already listed
- [x] Clear and concise description
- [x] Valid, working link (https://7ovr.com)
- [x] Correct section assigned (Registries)
- [x] No manual date (the add-dates workflow stamps it on merge, per the template)
