### PR TITLE
Add Rust (egui) port: ouroboros-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@
 | React Native | React Native port of shadcn/ui. | [Link](https://github.com/Mobilecn-UI/nativecn-ui) | 2024-12-27T12:56:05.000Z |
 | React Native (recommended) | React Native port of shadcn/ui (recommended). | [Link](https://github.com/mrzachnugent/react-native-reusables) | 2024-12-27T12:56:05.000Z |
 | Ruby | Ruby port of shadcn/ui. | [Link](https://github.com/aviflombaum/shadcn-rails) | 2024-12-27T12:56:05.000Z |
+| Rust (egui) | Native Rust/egui port of the shadcn/ui design language. Token-first, with governance tests that fail the build on raw values. Live wasm storybook. | [Link](https://github.com/Type-zero-labs/ouroboros-ui) | 2026-07-07 |
 | Solid | Solid port of shadcn/ui. | [Link](https://github.com/hngngn/shadcn-solid) | 2024-12-27T12:56:05.000Z |
 | Svelte | Svelte port of shadcn/ui. | [Link](https://github.com/huntabyte/shadcn-svelte) | 2024-12-27T12:56:05.000Z |
 | Swift | Swift port of shadcn/ui. | [Link](https://github.com/Mobilecn-UI/swiftcn-ui) | 2024-12-27T12:56:05.000Z |


### PR DESCRIPTION
Adds **ouroboros-ui** to the **Ports** section — the first Rust/egui entry.

It's a native reimplementation of the shadcn/ui design *language* (semantic tokens, zinc aesthetic, 4px scale) for [egui](https://github.com/emilk/egui) — not a web wrapper. 60+ components, token-first, with governance tests that fail the build when a raw value bypasses the tokens.

- Repo (MIT): https://github.com/Type-zero-labs/ouroboros-ui
- Live wasm storybook: https://ouroboros-ui.typezerolabs.com/storybook/

Single-row addition in the Ports table, alphabetical between Ruby and Solid.