### PR TITLE
Add LocalMode to Libs and Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@
 | lingua-time | Smart datetime picker with natural language input. | [Link](https://github.com/nainglinnkhant/lingua-time) | 2024-12-27T12:56:05.000Z |
 | linked-chart | Chart component linked with data-table. | [Link](https://github.com/ardasisbot/linked-chart) | 2025-02-03T19:05:16.000Z |
 | loading-ui | Curated, copy-friendly spinners, loaders, and loading-state animations for the web—free and open source. | [Link](https://loading-ui.com/) | 2026-04-25T12:00:00.000Z |
+| LocalMode | Local-first AI UI registry with 107 copy-owned primitives and 36 composed blocks (chat, RAG, Whisper transcription, CLIP image search) that run entirely in the browser, no servers or API keys. Installable via the shadcn CLI. | [Link](https://localmode.ai) | |
 | lukacho-ui | Next Generation UI Components. | [Link](https://ui.lukacho.com/components) | 2024-12-27T12:56:05.000Z |
 | magicui | React components for landing pages with tailwindcss + framer motion. | [Link](https://magicui.design) | 2024-12-27T12:56:05.000Z |
 | maily.to | Notion-like powerful email editor. | [Link](https://github.com/arikchakma/maily.to) | 2024-12-27T12:56:05.000Z |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@
 | lingua-time | Smart datetime picker with natural language input. | [Link](https://github.com/nainglinnkhant/lingua-time) | 2024-12-27T12:56:05.000Z |
 | linked-chart | Chart component linked with data-table. | [Link](https://github.com/ardasisbot/linked-chart) | 2025-02-03T19:05:16.000Z |
 | loading-ui | Curated, copy-friendly spinners, loaders, and loading-state animations for the web—free and open source. | [Link](https://loading-ui.com/) | 2026-04-25T12:00:00.000Z |
-| LocalMode | Local-first AI UI registry with 107 copy-owned primitives and 36 composed blocks (chat, RAG, Whisper transcription, CLIP image search) that run entirely in the browser, no servers or API keys. Installable via the shadcn CLI. | [Link](https://localmode.ai) | |
+| localmode | Local-first AI UI registry with 107 copy-owned primitives and 36 composed blocks (chat, RAG, Whisper transcription, CLIP image search) that run entirely in the browser, no servers or API keys. Installable via the shadcn CLI. | [Link](https://localmode.ai) | |
 | lukacho-ui | Next Generation UI Components. | [Link](https://ui.lukacho.com/components) | 2024-12-27T12:56:05.000Z |
 | magicui | React components for landing pages with tailwindcss + framer motion. | [Link](https://magicui.design) | 2024-12-27T12:56:05.000Z |
 | maily.to | Notion-like powerful email editor. | [Link](https://github.com/arikchakma/maily.to) | 2024-12-27T12:56:05.000Z |


### PR DESCRIPTION
This PR adds **LocalMode** to the **Libs and Components** section, in alphabetical order (between `loading-ui` and `lukacho-ui`).

LocalMode is an open-source (MIT) shadcn registry of local-first AI UI: 107 copy-owned primitives and 36 composed blocks (chat, RAG, Whisper transcription, CLIP image search) that run entirely in the browser, with no servers or API keys. You install a block with the shadcn CLI and own the copied `.tsx`, same as shadcn/ui.

- Registry and live demos: https://localmode.ai
- Repo: https://github.com/LocalMode-AI/LocalMode

## Checklist
- [x] Verified the resource is listed in alphabetical order within its section.
- [x] Checked that the resource is not already listed.
- [x] Provided a clear and concise description of the resource.
- [x] Included a valid and working link to the resource.
- [x] Assigned the correct section (Libs and Components).
- [x] Open-source and freely accessible (MIT).
