### PR TITLE
Add AI Canvas to Libs and Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 | adapttable | Data table for shadcn/ui in one import — URL-synced state, declarative filters with chips, column management and virtualization. Unstyled core pre-wired with the shadcn class preset. | [Link](https://github.com/orwa-mahmoud/adapttable) | 2026-07-11 |
 | agents-ui | Agents UI is LiveKit’s open source component library built with React and shadcn for designing voice agent interfaces. Start with production-ready defaults, then customize every detail to match your brand. | [Link](https://livekit.io/ui) | 2026-03-03T17:54:22.000Z |
 | agentcn | Production-ready agents, made simple. Ready to use, customizable AI agent recipes. Built on Eve and Flue. | [Link](https://agentcn.vercel.app) | 2026-06-21T12:00:00.000Z |
+| AI Canvas | Open-source animated React and Tailwind components, blocks, and design systems, installable via the shadcn CLI. | [Link](https://aicanvas.me) | 2026-07-21 |
 | animated-header | Vercel-like animated header. | [Link](https://github.com/mehrdadrafiee/animated-header) | 2025-10-25T16:09:52.000Z |
 | animated-tabs | Vercel-like animated tabs. | [Link](https://github.com/mehrdadrafiee/animated-tabs) | 2025-04-06T14:14:05.000Z |
 | approvals-ui | Approval workflow components for React Flow: quorum gates, amount thresholds, a policy lint (segregation of duties, single approver on high value), and plain-language editing behind a human review gate. Distributed as a shadcn registry. | [Link](https://approvals-ui.vercel.app) | 2026-07-08 |


### PR DESCRIPTION
Adds **AI Canvas** to the Libs and Components list (placed alphabetically).

AI Canvas is an open-source (MIT) registry of animated React and Tailwind components, blocks, design systems, and templates, installable with the shadcn CLI:

```
npx shadcn@latest add @aicanvas/<component>
```

- Site: https://aicanvas.me
- Registry: https://aicanvas.me/r/registry.json
- Already listed in the official shadcn registry directory (ui.shadcn.com/docs/directory)

Thanks for maintaining this list!