### PR TITLE
Add Sora UI to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |
+| sora-ui | Motion-first React component registry on the shadcn model. Install @soralabs/* primitives via the CLI, own the code in your repo. Includes scroll reveals, text effects, magnetic UI, and more, powered by Motion and GSAP with reduced-motion support built in. | [Link](https://ui.soralabs.io.vn/) | 2026-07-24T00:00:00.000Z |
 | tailark | Shadcn blocks for building modern marketing websites | [Link](https://tailark.com) | 2026-02-06T17:56:55.000Z |
 | undraw-cn | Beautiful, customizable React components for unDraw illustrations. | [Link](https://undraw-cn.vaatun.com) | 2025-12-04T15:15:06.000Z |
 


### PR DESCRIPTION
## Summary
- Add Sora UI to the Registries table — a motion-first React component registry on the shadcn model
- Install via `npx shadcn@latest add @soralabs/*`, own the code in your repo
- Ships scroll reveals, text effects, magnetic UI, and more, powered by Motion and GSAP with reduced-motion support built in
- Includes a docs MCP server so AI assistants (Cursor, Claude) can search components and install guides

## Test plan
- [x] Entry added in alphabetical order in the Registries table
- [x] Link verified: https://ui.soralabs.io.vn/