### PR TITLE
feat: add Identity Forge to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@
 | 7ovr | Free, production-ready blocks built on Base UI for marketing and application UIs. Copy, paste, and ship in minutes. | [Link](https://7ovr.com/?utm_source=awesome-shadcn-ui&utm_medium=referral&utm_campaign=directory) | 2026-07-04T01:23:53.331Z |
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
+| identityforge | Judged design kit registry: each theme ships 28 semantic color tokens in light + dark, a real font pairing, motifs and do's & don'ts, installable with `npx shadcn add`. | [Link](https://identityforge.io/kits) | 2026-07-27T00:00:00.000Z |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@
 | 7ovr | Free, production-ready blocks built on Base UI for marketing and application UIs. Copy, paste, and ship in minutes. | [Link](https://7ovr.com/?utm_source=awesome-shadcn-ui&utm_medium=referral&utm_campaign=directory) | 2026-07-04T01:23:53.331Z |
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
-| identityforge | Judged design kit registry: each theme ships 28 semantic color tokens in light + dark, a real font pairing, motifs and do's & don'ts, installable with `npx shadcn add`. | [Link](https://identityforge.io/kits) | 2026-07-27T00:00:00.000Z |
+| Identity Forge | A design kit registry with shadcn themes containing 28 semantic color tokens in light and dark. Kit pages include font pairings, motifs, and DESIGN.md guidance for coding agents. | [Link](https://identityforge.io/kits) | |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**

A shadcn registry of complete design kits. Each `registry:theme` carries 28 semantic color tokens in light and dark. Kit pages also document a font pairing, layout and elevation rules, motifs, and do's and don'ts so agents have more than a palette to work from.

Install a theme with the standard shadcn command:

```sh
npx shadcn@latest add https://identityforge.io/r/ambient-sage.json
```

Browse the kits at https://identityforge.io/kits. Every Free kit exposes a registry item at `/r/<slug>.json`.

## Which section does it belong to?

- [x] Registries

## Checklist

- [x] shadcn/ui related, with standard `registry:theme` items consumable by `npx shadcn@latest add`
- [x] Documented, with tokens, fonts, and the install command shown on each kit page
- [x] Actively maintained
- [x] Row added alphabetically to the Registries table, matching the existing column format
