### PR TITLE
feat: Add components to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@
 | 5devs | A website to get fake Brazilian data for testing purposes. | [Link](https://www.5devs.com.br/) | 2024-12-27T12:56:05.000Z |
 | bento-hub | BentoHub is an application where you can create a bento grid for your GitHub profile readme. | [Link](https://github.com/amittam104/BentoHub) | 2024-12-27T12:56:05.000Z |
 | cheatsheet | A comprehensive, interactive reference for shadcn/ui components with live previews, code examples, and instant copy functionality. | [Link](https://shadcnstore.com/cheatsheet/) | 2025-09-23T23:27:50.000Z |
+| components | Claude Code skill that maps a described UI effect to one of 39 showpiece components across Aceternity, Magic UI, ReactBits, Cult UI, and 21st.dev, fetches it live via each library's own registry command, and adapts it to the project's brand tokens. Pointer-only, with per-entry license tracking. | [Link](https://github.com/AnayDhawan/Components) | 2026-07-31 |
 | cut-it | Link shortener built using Next.js App Router, Server Actions, Drizzle ORM, Turso, and styled with shadcn/ui. | [Link](https://github.com/mehrabmp/cut-it) | 2024-12-27T12:56:05.000Z |
 | country-data-in-charts | Globe Graph is a web app that visualizes countries' data like GDP, GDP per capita, and population in different years using many charts. | [Link](https://globe-graph.vercel.app/) | 2024-12-27T12:56:05.000Z |
 | cv-forge | Resume builder built with @shadcn/ui, react-hook-form, and react-pdf. | [Link](https://cvforge.app) | 2024-12-27T12:56:05.000Z |


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**

`components` is a Claude Code skill that gives an AI coding agent a real menu of showpiece UI instead of letting it hand-write a scroll-driven MacBook or a WebGL globe from scratch. It maps a described effect ("make the hero pop, laptop opening on scroll") to one of 39 curated showpiece components across Aceternity, Magic UI, ReactBits, Cult UI, and 21st.dev, runs that library's own shadcn registry command live at build time, installs the dependencies, and adapts the result to the project's brand tokens (colors, dark mode, spacing, and `prefers-reduced-motion`).

It is pointer-only by design: no component code is vendored into the repo, so you always get the current upstream version and the upstream license travels with it. Every entry's license is verified and recorded in ATTRIBUTION.md.

Relevant to this list because it is a consumer of shadcn registries rather than another registry: it makes the existing ecosystem (several entries of which are already listed here) reachable from an agent.

## **Which section does it belong to?**
- [ ] Libs and Components
- [ ] Plugins and Extensions
- [ ] Colors and Customizations
- [ ] Animations
- [x] Tools
- [ ] Websites and Portfolios Inspirations
- [ ] Platforms
- [ ] Ports
- [ ] Design System
- [ ] Boilerplates / Templates

**Additional details (optional)**

Repo: https://github.com/AnayDhawan/Components (Apache-2.0, v1.1.1). README has a demo clip of the workflow and the full showpiece table.

## **Checklist**
- [x] I verified that the resource is listed in alphabetical order within its section.
- [x] I checked that the resource is not already listed.
- [x] I provided a clear and concise description of the resource.