### PR TITLE
feat: add zyeon-ui to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |
 | tailark | Shadcn blocks for building modern marketing websites | [Link](https://tailark.com) | 2026-02-06T17:56:55.000Z |
 | undraw-cn | Beautiful, customizable React components for unDraw illustrations. | [Link](https://undraw-cn.vaatun.com) | 2025-12-04T15:15:06.000Z |
+| zyeon-ui | 353 React + Tailwind components where every item ships with live preview, full source, its generation prompt and a concept map — installable via the shadcn CLI or by AI agents over MCP. | [Link](https://ui.zyeon.ai) | 2026-08-01T12:00:00.000Z |
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**
> Zyeon UI is a shadcn-compatible registry of 353 React + Tailwind components. What makes it different: every component ships as a four-piece kit — live preview, full source in semantic tokens, the generation prompt that produced it, and a concept map of the interaction — so both humans and AI agents can install and correctly restyle it. Free components (283) install with the standard shadcn CLI with no account; it also exposes an MCP server so coding agents can search the catalog by describing the problem and install components directly.

## **Which section does it belong to?**
- [x] Registries

## Checklist
- [x] The resource is shadcn/ui related (shadcn registry, installable via `npx shadcn add`)
- [x] Well-documented (each component has full docs, plus markdown endpoints and llms.txt)
- [x] Actively maintained

Site: https://ui.zyeon.ai · Catalog repo: https://github.com/Zyeon-AI/zyeon-ui-components