### PR TITLE
feat: Add interlace-ui to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@
 | 7ovr | Free, production-ready blocks built on Base UI for marketing and application UIs. Copy, paste, and ship in minutes. | [Link](https://7ovr.com/?utm_source=awesome-shadcn-ui&utm_medium=referral&utm_campaign=directory) | 2026-07-04T01:23:53.331Z |
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
+| interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) |  |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |


### PR DESCRIPTION
**What is it?** `interlace-ui` is an open-source shadcn/ui registry serving the theme baseline, layout and accessibility primitives, and MDX components used across the Interlace documentation sites. Installable with the shadcn CLI from https://ds.interlace.tools.

**Section:** Registries

**Checklist**
- [x] Listed in alphabetical order within its section (between `efferd` and `more-shadcn`).
- [x] Checked that the resource is not already listed.
- [x] Clear and concise description.
- [x] Valid and working link.
- [x] Correct section assigned.
- [x] Date cell left empty for the automated system.
