### PR TITLE
feat: Add wa-ui to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |
 | tailark | Shadcn blocks for building modern marketing websites | [Link](https://tailark.com) | 2026-02-06T17:56:55.000Z |
 | undraw-cn | Beautiful, customizable React components for unDraw illustrations. | [Link](https://undraw-cn.vaatun.com) | 2025-12-04T15:15:06.000Z |
+| wa-ui | A registry of WhatsApp Web chat components — chat bubbles, message input, voice and media bubbles, and Meta Business message templates — built on WhatsApp's WDS design tokens with light and dark modes. | [Link](https://ui.meta-cloud-api.site) | 2026-08-03 |
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**

[wa-ui](https://ui.meta-cloud-api.site) is an open-source shadcn/ui registry of WhatsApp Web chat components, built on WhatsApp's WDS (WhatsApp Design System) tokens — the same CSS variables WhatsApp Web ships — with light and dark mode variants.

It targets developers building on the WhatsApp Cloud API (support tools, CRM inboxes, SaaS integrations) who otherwise have to rebuild the entire chat UI from scratch. Components include chat bubbles with tails and read receipts, message input, image/voice/file bubbles, typing indicator, reaction pills, and the Meta Business message templates (URL, phone, copy_code, flow, OTP, catalog, carousel).

Stack: Tailwind CSS v4, @base-ui/react primitives, React 19. MIT licensed.

```bash
npx shadcn@latest add https://ui.meta-cloud-api.site/r/chat-bubble.json
```

- Demo: https://ui.meta-cloud-api.site
- Registry: https://ui.meta-cloud-api.site/r/registry.json
- Source: https://github.com/froggy1014/wa-ui

## **Which section does it belong to?**
- [ ] Libs and Components
- [ ] Plugins and Extensions
- [ ] Colors and Customizations
- [ ] Animations
- [ ] Tools
- [ ] Websites and Portfolios Inspirations
- [ ] Platforms
- [ ] Ports
- [ ] Design System
- [ ] Boilerplates / Templates
- [x] Registries

**Additional details (optional)**

Every component is independently installable — each has its own registry item, so you only pull what you need. All 16 components are live and browsable on the demo site.

## **Checklist**
- [x] I verified that the resource is listed in alphabetical order within its section.
- [x] I checked that the resource is not already listed.
- [x] I provided a clear and concise description of the resource.
- [x] I included a valid and working link to the resource.
- [x] I assigned the correct section to the resource.
