### PR TITLE
feat: Add shadscan to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@
 | shadcn-pricing-page-generator | The easiest way to get a React pricing page with shadcn/ui, Radix UI, and/or Tailwind CSS. | [Link](https://shipixen.com/shadcn-pricing-page) | 2024-12-27T12:56:05.000Z |
 | shadcn-theme-editor | Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects. | [Link](https://shadcnthemeeditor.vercel.app) | 2024-12-27T12:56:05.000Z |
 | shadcn-zod-form | CLI tool to generate shadcn/ui forms from Zod schemas. | [Link](https://github.com/ilyichv/shadcn-zod-form) | 2024-12-27T12:56:05.000Z |
+| shadscan | Deterministic UI audits for shadcn apps, built for your terminal, your CI, and your AI agent. Scores accessibility, UI states, navigation, forms, metadata, and production polish with cited evidence and agent-ready fixes. | [Link](https://shadscan.com) | 2026-08-04 |
 | sharable-form-builder | A sharable form builder for creating forms and sharing your form link, based on shadcn/ui and Next.js. | [Link](https://github.com/ayoubben18/sharable-form-builder) | 2024-12-27T12:56:05.000Z |
 | shoogle | A shadcn search engine | [Link](https://shoogle.dev/) | 2026-02-13T02:05:41.000Z |
 | slidytabs | A tool that adds a sliding indicator animation to shadcn `<Tabs />` without changing how you use or customize the component | [Link](https://slidytabs.dev) | 2026-01-23T21:13:51.000Z |


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**

[shadscan](https://shadscan.com) is an open-source (MIT) CLI that runs deterministic UI audits on shadcn applications. You point it at a project and it scores accessibility, UI states, navigation, forms, metadata, and production polish, citing the exact file and line behind every finding.

It is deterministic rather than AI-generated: the same code always produces the same score, so it works as a CI gate (`--fail-under`) and a pre-commit check, not just a one-off report. Findings come with agent-ready fix instructions, which makes it useful for the "have Claude/Cursor fix my UI" workflow a lot of shadcn users are already in.

Run it with no install:

```bash
npx @shadscan/cli /path/to/app
```

It understands the shadcn ecosystem specifically — reads `components.json`, resolves your aliases, and supports Next.js, TanStack Start, Vite, and Laravel Inertia projects.

## **Which section does it belong to?**
- [ ] Libs and Components
- [ ] Plugins and Extensions
- [ ] Colors and Customizations
- [ ] Animations
- [x] Tools
- [ ] Websites and Portfolios Inspirations
- [ ] Platforms
- [ ] Ports
- [ ] Design System
- [ ] Boilerplates / Templates

Tools rather than Plugins and Extensions, since that section is IDE and browser extensions and this is a CLI. It sits alongside the existing `shadcn-zod-form` CLI entry.

**Additional details (optional)**

- Source: https://github.com/TheOrcDev/shadscan (MIT, 400+ stars)
- Package: https://www.npmjs.com/package/@shadscan/cli
- Free and open source, no paid tier required to use the CLI.
- There is also a hosted scanner at https://shadscan.com/scan for auditing a public GitHub repository from the browser, and a full rule catalog at https://shadscan.com/rules.

## **Checklist**
- [x] I verified that the resource is listed in alphabetical order within its section.
- [x] I checked that the resource is not already listed.
- [x] I provided a clear and concise description of the resource.
- [x] I included a valid and working link to the resource.
- [x] I assigned the correct section to the resource.

One line added to the Tools table, placed between `shadcn-zod-form` and `sharable-form-builder`. Nothing else in the README is touched.

Note on the Date column: the template says to leave it empty, but the recent merged entries carry a manual date and every other row has one, so I matched the existing rows. Happy to blank it if you would rather the automation fill it.