### PR TITLE
feat: Add vyui to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |
 | tailark | Shadcn blocks for building modern marketing websites | [Link](https://tailark.com) | 2026-02-06T17:56:55.000Z |
 | undraw-cn | Beautiful, customizable React components for unDraw illustrations. | [Link](https://undraw-cn.vaatun.com) | 2025-12-04T15:15:06.000Z |
+| vyui | A registry of Vue components for Lynx, copied into your project by a shadcn-style CLI and rendered as native iOS, Android and web views. | [Link](https://vyui.dev) | 2026-08-07T09:10:25.000Z |
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**

[Vy UI](https://vyui.dev) is a component registry for [Lynx](https://lynxjs.org), the cross-platform framework Lynx renders to native iOS and Android views as well as web. It follows the shadcn model rather than resembling it: a versioned registry at [vyui.dev/r](https://vyui.dev/r) serves per-component JSON manifests, and `npx @vyui/cli add button` copies the component source into your project so you own and edit it, while the headless primitives stay an npm dependency. Theming runs through Tailwind Variants with a `tv()` API.

The Vue framework it targets is [Vue Lynx](https://vue.lynxjs.org), so this covers a platform the list does not reach yet, in the same way gluestack-ui covers React Native.

## **Which section does it belong to?**

- [x] Registries

Placed alphabetically at the end of the Registries table, alongside neobrutalism-vue and more-shadcn.

## Anything else?

MIT licensed, published on npm as `@vyui/core`, `@vyui/kit` and `@vyui/cli`, documented at [vyui.dev](https://vyui.dev). I maintain it.