### PR TITLE
Improve ui-beats description

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@
 | twblocks | Website blocks based on shadcn & Radix. | [Link](https://github.com/tommyjepsen/twblocks) | 2024-12-27T12:56:05.000Z |
 | tweet-to-code | Twitter design recreations as code. | [Link](https://tweet-to-code.vercel.app/) | 2024-12-27T12:56:05.000Z |
 | uiable | UIAble is a free, open-source UI system that extends shadcn/ui with a vivid design system, reusable React components, and complete code ownership. | [Link](https://github.com/codedthemes/uiable) | 2026-07-16T01:46:46.956Z |
-| ui-beats | Animated React Components collection. | [Link](https://uibeats.com) | 2024-12-27T12:56:05.000Z |
+| ui-beats | Animated React components installable from its own registry with the shadcn CLI, each with a props table, interactive playground and reduced-motion support. | [Link](https://uibeats.com) | 2024-12-27T12:56:05.000Z |
 | ui-flexnative | A collection of customizable UI blocks with interactive live previews | [Link](https://ui.flexnative.com) | 2026-04-24T19:36:31.000Z |
 | ui-layouts | UI Layouts isn’t just a library. It’s a complete toolkit with components, effects, design tools, and ready-to-use blocks, everything you need to build modern interfaces, faster. | [Link](https://www.ui-layouts.com/) | 2025-10-15T16:30:14.000Z |
 | ui-nference-sh | a shadcn registry of react ui components for building ai-powered applications, chatbots, and ai agent interfaces. | [Link](https://ui.inference.sh/) | 2026-02-13T17:47:21.000Z |


### PR DESCRIPTION
Improves the description of the existing `ui-beats` row in **Libs and Components**.

The current cell — "Animated React Components collection." — doesn't meet the bar in CONTRIBUTING ("the description says what it is... a reader should be able to tell whether they want it without opening the link"). This replaces it with one concrete sentence covering what the project actually is and how you install it.

Following the guidelines:
- One sentence, English, no technology list, no extra links in the description
- Name unchanged — `ui-beats` matches the lowercase house style used across this section, so alphabetical position is untouched
- Existing Date cell preserved, since the entry landed in Dec 2024 and the workflow only fills empty cells
- Link unchanged and live

Diff is a single line.
