### PR TITLE
feat: Add crafterui to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@
 | 7ovr | Free, production-ready blocks built on Base UI for marketing and application UIs. Copy, paste, and ship in minutes. | [Link](https://7ovr.com/?utm_source=awesome-shadcn-ui&utm_medium=referral&utm_campaign=directory) | 2026-07-04T01:23:53.331Z |
 | atelier-ui | A React Three Fiber and Motion component system for React and Next.js. WebGL galleries, interactive cursors, smooth scroll effects and page transitions, built on one shared canvas and one scroll loop. | [Link](https://github.com/whatisjery/atelier-ui) | 2026-08-11T14:27:05.834Z |
 | beui | Copy-paste animated components built on Framer Motion and Tailwind. Free and open source. | [Link](https://beui.dev/) | 2026-08-11T14:27:05.834Z |
+| crafterui | Motion and interaction components for React and Tailwind — 3D carousels, scroll letter reveals, a Dynamic Island, cursor hit-testing and rolling countdowns — installed with the shadcn CLI and owned as source. | [Link](https://crafterui.com) |
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |


### PR DESCRIPTION
**What is it?**

crafterui is an open-source registry of motion and interaction components for React and Tailwind: 3D carousels, scroll letter reveals, a Dynamic Island, cursor hit-testing and rolling countdowns. Every component installs with the shadcn CLI and is copied into your project as source, so nothing is added to your runtime dependencies. MIT licensed, with a live demo and the full source for each component on the site.

```bash
npx shadcn@latest add https://crafterui.com/r/letter-reveal.json
```

Site: https://crafterui.com
Source: https://github.com/SriSomanaath/crafterui
Registry index: https://crafterui.com/r/registry.json

**Which section does it belong to?**

Registries — it is installable with `npx shadcn add` from its own registry. Inserted alphabetically between `beui` and `dominik-ui`.

**Checks**

- One resource, one pull request.
- Three columns, no Date cell and no trailing pipe, per CONTRIBUTING.
- Name and URL are not already in the README.
- Links resolve: site, source and registry all return 200.