### PR TITLE
Add Blode UI to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@
 | 7ovr | Free, production-ready blocks built on Base UI for marketing and application UIs. Copy, paste, and ship in minutes. | [Link](https://7ovr.com/?utm_source=awesome-shadcn-ui&utm_medium=referral&utm_campaign=directory) | 2026-07-04T01:23:53.331Z |
 | atelier-ui | A React Three Fiber and Motion component system for React and Next.js. WebGL galleries, interactive cursors, smooth scroll effects and page transitions, built on one shared canvas and one scroll loop. | [Link](https://github.com/whatisjery/atelier-ui) | 2026-08-11T14:27:05.834Z |
 | beui | Copy-paste animated components built on Framer Motion and Tailwind. Free and open source. | [Link](https://beui.dev/) | 2026-08-11T14:27:05.834Z |
+| Blode UI | An open-source registry of accessible React components built on Base UI and Tailwind CSS v4, installable with the shadcn CLI. | [Link](https://blode.co/ui) |
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |


### PR DESCRIPTION
Adds Blode UI to the Registries section.

**Blode UI** is an open-source shadcn registry of React components built on Base UI and Tailwind CSS v4. Install with the shadcn CLI, then own the source.

- Site: https://blode.co/ui
- Docs: https://blode.co/ui/docs
- Source: https://github.com/mblode/blode-ui (MIT)
- Registry: https://blode.co/ui/registry.json

## Against the five rules

- **About shadcn/ui:** it is a registry you install from with the shadcn CLI, not a project that happens to use shadcn somewhere.
- **Free to use:** MIT, public repo, no paid tier.
- **Link works and is the right one:** `https://blode.co/ui` returns 200 and is the project's own site. No tracker, no redirect.
- **Description says what it is:** one sentence, no technology list, no extra links.
- **Not already listed:** no `blode` match anywhere in the README.

## Format

Three columns, no date cell and no trailing empty pipe, so the workflow can fill it on merge. Placed alphabetically between `beui` and `dominik-ui`. One resource, one file, +1 −0.