### PR TITLE
feat: Add keyline-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |
+| keyline-icons | 503 MIT-licensed icons in stroke, duotone and fill, drawn on one 24×24 grid. Installable with the shadcn CLI, with a React package matching lucide's API. | [Link](https://keylineicons.com/) |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |


### PR DESCRIPTION
---
name: "feat: Add new awesome resource"
about: "Propose adding a new awesome resource related to shadcn/ui"
labels:
  - feature
---

## Describe the awesome resource you want to add

**What is it?**
503 MIT-licensed icons in stroke, duotone and fill, drawn on one 24×24 grid. Installable with the shadcn CLI, with a React package matching lucide's API.

## **Which section does it belong to?**
- [x] Registries

## **Additional details (optional)**
Resource URL: https://keylineicons.com/

Submitted by: @Mr-Zafar

## **Checklist**
- [x] Resource is automatically sorted alphabetically within its section.
- [x] Duplicate checking is performed automatically.
- [x] Table formatting is handled automatically.
- [x] Includes a valid and working link to the resource.
- [x] Automatically assigned the correct section to the resource.
