### PR TITLE
Add ns-ui to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
+| ns-ui | 389 React components, each built around a single interaction — canvas, motion and glass, themed by your own CSS tokens in light and dark. MIT, with a CLI and an MCP server. | [Link](https://design.helpmarq.com) |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |
 | sora-ui | Motion-first React component registry on the shadcn model. Install @soralabs/* primitives via the CLI, own the code in your repo. Includes scroll reveals, text effects, magnetic UI, and more, powered by Motion and GSAP with reduced-motion support built in. | [Link](https://ui.soralabs.io.vn/) | 2026-08-11T14:27:05.834Z |
 | tailark | Shadcn blocks for building modern marketing websites | [Link](https://tailark.com) | 2026-02-06T17:56:55.000Z |


### PR DESCRIPTION
One row in Registries, inserted alphabetically between neobrutalism-vue and registry.directory. No Date cell, per CONTRIBUTING.

**ns-ui** — https://design.helpmarq.com · MIT · https://github.com/nikolas-sapa/ns-ui

389 self-contained React components for React 19 and Tailwind v4, installable with `npx shadcn add https://design.helpmarq.com/r/<name>.json`. Each is built around a single interaction, and a Playwright screenshot suite fails any component whose hover renders byte-identical to its resting state or whose dark and light renders are the same. Free and open source, no paid tier. There is also a CLI (`@nikolas.sapa/ns-ui`) and an MCP server (`@nikolas.sapa/ns-ui-mcp`).

Checked before opening: no existing row for this name or URL anywhere in the README.