### PR TITLE
Add Angular (Base UI) to Ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@
 
 | Name | Description | Link | Date |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------- |
+| Angular (Base UI) | CLI-first Angular + Tailwind copy-in port of the shadcn/ui model. | [Link](https://github.com/Base-ui-ng/base-ui) |
 | Angular (spartan) | Angular port of shadcn/ui. | [Link](https://github.com/goetzrobin/spartan) | 2024-12-27T12:56:05.000Z |
 | Basecoat | Vanilla HTML, CSS and JS port of shadcn/ui. | [Link](https://basecoatui.com) | 2025-07-07T12:15:40.000Z |
 | Blazor (simple/ui) | Razor component library for Blazor, inspired by shadcn/ui. | [Link](https://sysinfocus.github.io/shadcn-inspired/) | 2024-12-27T12:56:05.000Z |


### PR DESCRIPTION
## What

Add **Angular (Base UI)** to the Ports table. Spartan stays as the existing Angular row.

- Name format per contributing: `Language (project)`
- No Date cell (workflow stamps it)
- Alphabetical: `Angular (Base UI)` before `Angular (spartan)`
- Link: https://github.com/Base-ui-ng/base-ui
- Docs: https://base-ui.net
- Free CLI copy-in (`npx base-ui-cli add`); not an npm UI runtime
- Distinct from MUI Base UI (React)

Spartan is Helm + `@spartan-ng/brain`. Base UI copies behavior and Tailwind source with no runtime UI package. Both can reasonably live under Ports.