### PR TITLE
Add mischief-ui to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |
+| mischief-ui | 98 open-source React components for shadcn projects: an agent's chat surface, document viewers for PDF, DOCX and CSV, a data table, and WebGL backdrops that take their colours from your theme. | [Link](https://ui.tinkererslabs.com) |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |
-| mischief-ui | Open-source React components for shadcn projects: an agent's chat surface, document viewers for PDF, DOCX and CSV, a data table, and WebGL backdrops that take their colours from your theme. | [Link](https://ui.tinkererslabs.com) |
+| mischief-ui | A playful, high-utility shadcn registry: PDF, DOCX and JSON viewers, redaction and bounding boxes, agent chat with tool calls, data tables, command palettes, OTP inputs, and shader fields. | [Link](https://ui.tinkererslabs.com) |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@
 | dominik-ui | Opinionated components and tools for building modern websites and AI interfaces. | [Link](https://dominikkoch.dev/ui) | 2026-06-21T12:00:00.000Z |
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |
-| mischief-ui | 98 open-source React components for shadcn projects: an agent's chat surface, document viewers for PDF, DOCX and CSV, a data table, and WebGL backdrops that take their colours from your theme. | [Link](https://ui.tinkererslabs.com) |
+| mischief-ui | Open-source React components for shadcn projects: an agent's chat surface, document viewers for PDF, DOCX and CSV, a data table, and WebGL backdrops that take their colours from your theme. | [Link](https://ui.tinkererslabs.com) |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |


### PR DESCRIPTION
Adds `mischief-ui` to Registries.

[Mischief UI](https://ui.tinkererslabs.com) is an open-source, MIT-licensed shadcn registry: PDF, DOCX and JSON viewers, redaction and bounding boxes, agent chat with tool calls, data tables, command palettes, OTP inputs, and shader fields.

```bash
npx shadcn@latest add @mischief/metaballs
```

- Free and open source, MIT, no paid tier
- Installable with the shadcn CLI; every item resolves today
- Not already listed, and the row is alphabetical between `interlace-ui` and `more-shadcn`
- Three columns, no Date cell, one resource in this pull request