### PR TITLE
Add wensity to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@
 | tailark | Shadcn blocks for building modern marketing websites | [Link](https://tailark.com) | 2026-02-06T17:56:55.000Z |
 | undraw-cn | Beautiful, customizable React components for unDraw illustrations. | [Link](https://undraw-cn.vaatun.com) | 2025-12-04T15:15:06.000Z |
 | wa-ui | A registry of WhatsApp Web chat components — chat bubbles, message input, voice and media bubbles, and Meta Business message templates — built on WhatsApp's WDS design tokens with light and dark modes. | [Link](https://ui.meta-cloud-api.site) | 2026-08-11T14:27:05.834Z |
+| wensity | Free, MIT-licensed React UI primitives, components, and motion for Next.js and Tailwind CSS v4, themeable from one design token contract; a paid Pro catalog is also available. | [Link](https://ui.wensity.com) |
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Adds one row to **Registries**, placed alphabetically after `wa-ui`.

```
| wensity | Free, MIT-licensed React UI primitives, components, and motion for Next.js and Tailwind CSS v4, themeable from one design token contract; a paid Pro catalog is also available. | [Link](https://ui.wensity.com) |
```

### Against the checklist

- **About shadcn/ui** — a registry installable with the shadcn CLI. `@wensity` is in the official shadcn registry index, so `npx shadcn@latest add @wensity/button` works with no `components.json` configuration.
- **Free to use** — 70 items, all MIT, free with no account. There is a paid Pro catalog, and the description says so rather than presenting the paid catalog as free.
- **Link works** — points at the project's own site. No tracker redirect.
- **Description** — one concrete sentence, not a list of technologies.
- **Not already listed** — no existing `wensity` entry.

### Format

Three columns, no Date cell, one resource, alphabetical within the section. Source is at [wensity/registry](https://github.com/wensity/registry).