### PR TITLE
feat: Add Warren UI to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@
 | tailark | Shadcn blocks for building modern marketing websites | [Link](https://tailark.com) | 2026-02-06T17:56:55.000Z |
 | undraw-cn | Beautiful, customizable React components for unDraw illustrations. | [Link](https://undraw-cn.vaatun.com) | 2025-12-04T15:15:06.000Z |
 | wa-ui | A registry of WhatsApp Web chat components — chat bubbles, message input, voice and media bubbles, and Meta Business message templates — built on WhatsApp's WDS design tokens with light and dark modes. | [Link](https://ui.meta-cloud-api.site) | 2026-08-11T14:27:05.834Z |
+| warren-ui | Data-dense instrument-panel components for ops and monitoring consoles — panels, charts, heatmaps, timelines. Distributed as a shadcn registry. | [Link](https://warren.eduard3v.com) |
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
## Describe the awesome resource you want to add
Warren UI — data-dense instrument-panel React components (panel, sparkline, heatmap, ledger, incident-timeline, agent-trace, 48 components + foundation) distributed as a shadcn registry. MIT, React 19 + Tailwind v4. Installable via `npx shadcn@latest add https://warren.eduard3v.com/r/panel.json`.

## Which section does it belong to?
- [x] Registries

## Checklist
- [x] Alphabetical order within its section (after wa-ui, before wds)
- [x] Not already listed
- [x] Clear, concise description
- [x] Valid working link (https://warren.eduard3v.com)