### PR TITLE
Add n3wth to Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@
 | efferd | ready-to-use shadcn blocks that just work — modern, responsive, and built for speed. | [Link](http://efferd.com/) | 2026-03-05T23:46:18.000Z |
 | interlace-ui | Design-system registry for the Interlace docs sites: theme baseline, layout and accessibility primitives, and MDX components. Installable with the shadcn CLI. | [Link](https://ds.interlace.tools) | 2026-08-11T14:21:17.397Z |
 | more-shadcn | A collection of high-quality, copy-paste components for Svelte 5, built on top of shadcn-svelte. | [Link](https://more-shadcn.noair.fun/) | 2026-01-23T21:14:57.000Z |
+| n3wth | Flat, minimal, iOS-inspired design system with 49 components, hooks, and blocks installable via the shadcn CLI. | [Link](https://kit.n3wth.com) | 2026-09-01T22:00:00.000Z |
 | neobrutalism-vue | A vue-based registry of neobrutalism-styled Tailwind components. | [Link](https://github.com/michaelsieminski/neobrutalism-vue) | 2025-12-04T15:20:34.000Z |
 | registry.directory | A curated directory to discover, preview, and copy shadcn/ui registries. | [Link](https://github.com/rbadillap/registry.directory) | 2025-09-23T23:29:49.000Z |
 | sora-ui | Motion-first React component registry on the shadcn model. Install @soralabs/* primitives via the CLI, own the code in your repo. Includes scroll reveals, text effects, magnetic UI, and more, powered by Motion and GSAP with reduced-motion support built in. | [Link](https://ui.soralabs.io.vn/) | 2026-08-11T14:27:05.834Z |


### PR DESCRIPTION
## Summary

Adds n3wth (https://kit.n3wth.com) to the Registries section.

Public shadcn registry: 49 components, hooks, and blocks. Install with `npx shadcn@latest add https://kit.n3wth.com/r/button.json`.

## Checklist

- [x] Resource is shadcn/ui related
- [x] Registry is publicly accessible
- [x] Link works