### PR TITLE
feat: Add @sebas-dv/shadcn-theme-editor to Colors and Customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@
 | ewgenius/ui | Create custom themes for shadcn/ui effortlessly using vibrant palettes from Radix Colors. | [Link](https://ui.ewgenius.me/shadcn-radix-colors) | 2024-12-27T12:56:05.000Z |
 | gradient-picker | Fancy Gradient Picker built with shadcn/ui, Radix UI, and Tailwind CSS. | [Link](https://github.com/Illyism/gradient-picker) | 2024-12-27T12:56:05.000Z |
 | navnote/rangeen | Tool that helps you to create a colour palette for your website. | [Link](https://github.com/navnote/rangeen) | 2024-12-27T12:56:05.000Z |
+| @sebas-dv/shadcn-theme-editor | In-app overlay that edits shadcn (Tailwind v4 / OKLCH) theme tokens live and writes changes straight back to your globals.css via PostCSS, with OKLCH sliders and live WCAG contrast checks. | [Link](https://github.com/Sebas-DV/shadcn-theme-editor) |
 | shadesigner.com | A shadcn/ui Palette Generator & Theme Designer with a beautiful interface. | [Link](https://shadesigner.com) | 2024-12-27T12:56:05.000Z |
 | shadcn-ui-customizer | POC - shadcn/ui themes with color pickers. | [Link](https://github.com/Railly/shadcn-ui-customizer) | 2024-12-27T12:56:05.000Z |
 | shadcn theme editor | Shadcn Theme Editor is a user-friendly component designed to simplify the process of managing and customizing theme colors in Shadcn-based projects. | [Link](https://github.com/programming-with-ia/shadcn-theme-editor/) | 2024-12-27T12:56:05.000Z |


### PR DESCRIPTION
## Describe the awesome resource you want to add

**What is it?**
An in-app, Shadow-DOM **overlay** that edits shadcn/ui (Tailwind v4 / OKLCH) theme tokens live inside your running app — OKLCH L/C/H sliders, a native color picker, and live WCAG contrast badges — and on **Apply** it rewrites the changes straight back into your source `globals.css` with PostCSS (comments, order and OKLCH formatting preserved). Framework-agnostic: one Vite plugin covers Vite / Laravel+Inertia / TanStack / Astro / Remix / SvelteKit, and a `<ThemeEditor/>` component + CLI cover Next.js. MIT, dev-only (hard-blocked in production), published with npm provenance.

> Note: this is distinct from the existing "shadcn theme editor" (programming-with-ia) entry — that one is a React component; this is a framework-agnostic overlay that writes tokens back to your CSS file. I used the published package name `@sebas-dv/shadcn-theme-editor` to keep the Name unique.

## Which section does it belong to?
- [x] Colors and Customizations

## Checklist
- [x] I verified that the resource is listed in alphabetical order within its section.
- [x] I checked that the resource is not already listed (unique name + URL).
- [x] I provided a clear and concise description of the resource.
- [x] I included a valid and working link to the resource.
- [x] I assigned the correct section to the resource.

## Required Table Format

| @sebas-dv/shadcn-theme-editor | In-app overlay that edits shadcn (Tailwind v4 / OKLCH) theme tokens live and writes changes straight back to your globals.css via PostCSS, with OKLCH sliders and live WCAG contrast checks. | [Link](https://github.com/Sebas-DV/shadcn-theme-editor) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)